### PR TITLE
Update to new LibertyDSNP repository paths

### DIFF
--- a/designdocs/MESSAGE_STORAGE.md
+++ b/designdocs/MESSAGE_STORAGE.md
@@ -20,7 +20,7 @@ that will allow us to store these messages on chain.
 Storing messages on chain using **BlockNumber** and **SchemaId** as main and secondary keys
 using [StorageDoubleMap](https://docs.substrate.io/rustdocs/latest/frame_support/storage/trait.StorageDoubleMap.html) data structure provided in Substrate.
 
-![Data-Page-3 drawio](https://raw.githubusercontent.com/Liberty30/DesignDocs/main/img/main_storage_type.png?token=GHSAT0AAAAAABPAUB3DH5DW4MIJKDCKUDQEYS57U4Q)
+![Data-Page-3 drawio](https://raw.githubusercontent.com/LibertyDSNP/DesignDocs/main/img/main_storage_type.png?token=GHSAT0AAAAAABPAUB3DH5DW4MIJKDCKUDQEYS57U4Q)
 
 
 ### Main Storage types
@@ -136,12 +136,12 @@ any messages, to eliminate unnecessary DB reads. We can use a BitArray per Schem
 we would need to store this indexing data off-chain, and we can create jobs to create or update
 it periodically.
 
-![Data-OnChainAnnouncements drawio](https://raw.githubusercontent.com/Liberty30/DesignDocs/main/img/message_storage_bitvector.png?token=GHSAT0AAAAAABPAUB3DLXKOTEIG5OYRUZFAYS57YEA)
+![Data-OnChainAnnouncements drawio](https://raw.githubusercontent.com/LibertyDSNP/DesignDocs/main/img/message_storage_bitvector.png?token=GHSAT0AAAAAABPAUB3DLXKOTEIG5OYRUZFAYS57YEA)
 ## Alternatives and Rationale
 Storing messages on chain using a map of `schemaId` and `staring` index to a sequential fixed sized
 bucket.
 
-![Data-Page-2 drawio](https://raw.githubusercontent.com/Liberty30/DesignDocs/main/img/message_storage_alternative.png?token=GHSAT0AAAAAABPAUB3DTEWGIOKN5PNXSZJOYS57ZOA)
+![Data-Page-2 drawio](https://raw.githubusercontent.com/LibertyDSNP/DesignDocs/main/img/message_storage_alternative.png?token=GHSAT0AAAAAABPAUB3DTEWGIOKN5PNXSZJOYS57ZOA)
 
 ### Main Storage types
 - **Messages**

--- a/designdocs/README.md
+++ b/designdocs/README.md
@@ -4,8 +4,8 @@ To create a new design document, Please see the [Design Doc README](https://gith
 ## Accepted Design Documents
 
 * [On Chain Message Storage](MESSAGE_STORAGE.md)
-  * [Merged Pull Request](https://github.com/Liberty30/mrc/pull/15)
+  * [Merged Pull Request](https://github.com/LibertyDSNP/mrc/pull/15)
 * [Delegation](./delegation.md)
-  * [PR](https://github.com/Liberty30/mrc/pull/14)
+  * [PR](https://github.com/LibertyDSNP/mrc/pull/14)
 * [Message Schema(s)](./SCHEMA.md)
-  * [Merged Pull Request](https://github.com/Liberty30/mrc/pull/17)
+  * [Merged Pull Request](https://github.com/LibertyDSNP/mrc/pull/17)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MRC Team"]
 description = "Substrate node for mrc"
 license = "Apache-2.0"
 homepage = "https://unfinishedlabs.io/"
-repository = "https://github.com/liberty30/mrc/"
+repository = "https://github.com/LibertyDSNP/mrc/"
 edition = "2021"
 build = "build.rs"
 

--- a/pallets/msa/Cargo.toml
+++ b/pallets/msa/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://unfinishedlabs.io/"
 license = "Apache-2.0"
 name = "pallet-msa"
 publish = false
-repository = "https://github.com/liberty30/mrc/"
+repository = "https://github.com/libertyDSNP/mrc/"
 version = "0.1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Switching out `Liberty30` -> `LibertyDSNP`

Should be no more Liberty30 in the repo.

