### PR TITLE
PR CI will cancel previous runs

### DIFF
--- a/.github/workflows/build-params.json
+++ b/.github/workflows/build-params.json
@@ -7,6 +7,18 @@
   },
   {
     "os": "ubuntu-latest",
+    "target": "lint",
+    "run_on_event": "any",
+    "rust_toolchain": "nightly-2021-11-07"
+  },
+  {
+    "os": "ubuntu-latest",
+    "target": "tests",
+    "run_on_event": "any",
+    "rust_toolchain": "nightly-2021-11-07"
+  },
+  {
+    "os": "ubuntu-latest",
     "target": "build-runtime",
     "package": "mrc-runtime",
     "run_on_event": "push",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: [main]
-name: Build
+name: Build Main
 jobs:
   build_prep:
     name: build-prep

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -1,8 +1,9 @@
+name: Tests Pull Requests
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 on:
-  push:
-    branches: [main]
   pull_request:
-name: Tests
 jobs:
   tests:
     name: ${{ matrix.target }}
@@ -30,7 +31,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           default: true
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: ./ci/build.sh
         env:


### PR DESCRIPTION
Goal: Get tests to run faster

Solution in this PR: Stop the runners for prior commits in PRs.