### PR TITLE
replace vec with boundedvec issue #54

### DIFF
--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -22,7 +22,9 @@ pub mod weights;
 
 mod types;
 
-use frame_support::{dispatch::DispatchResult, ensure, pallet_prelude::Weight, traits::Get, BoundedVec};
+use frame_support::{
+	dispatch::DispatchResult, ensure, pallet_prelude::Weight, traits::Get, BoundedVec,
+};
 use sp_runtime::{traits::One, DispatchError};
 use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, prelude::*};
 
@@ -55,7 +57,7 @@ pub mod pallet {
 
 		/// The maximum size of a message [Byte]
 		#[pallet::constant]
-		type MaxMessageSizeInBytes: Get<u32>;
+		type MaxMessageSizeInBytes: Get<u32> + Clone;
 	}
 
 	#[pallet::pallet]
@@ -183,12 +185,12 @@ impl<T: Config> Pallet<T> {
 
 		'loops: for bid in from..to {
 			let block_number: T::BlockNumber = bid.into();
-			let list = <Messages<T>>::get(block_number, schema_id);
+			let list = <Messages<T>>::get(block_number, schema_id).into_inner();
 
 			let list_size: u32 =
 				list.len().try_into().map_err(|_| Error::<T>::TypeConversionOverflow)?;
 			for i in from_index..list_size {
-				let m: Message<T::AccountId> = list[i as usize].clone();
+				let m = list[i as usize].clone();
 				response.content.push(m.map_to_response(block_number));
 
 				if Self::check_end_condition_and_set_next_pagination(

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -10,6 +10,7 @@ use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
+use std::fmt::Formatter;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -54,8 +55,35 @@ impl system::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxMessagesPerBlock: u16 = 500;
+	pub const MaxMessagesPerBlock: u32 = 500;
 	pub const MaxMessageSizeInBytes: u32 = 100;
+}
+
+impl std::fmt::Debug for MaxMessagesPerBlock {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("MaxMessagesPerBlock")
+			.field("v", &MaxMessagesPerBlock::get())
+			.finish()
+	}
+}
+impl std::fmt::Debug for MaxMessageSizeInBytes {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("MaxMessageSizeInBytes")
+			.field("v", &MaxMessageSizeInBytes::get())
+			.finish()
+	}
+}
+
+impl PartialEq for MaxMessagesPerBlock {
+	fn eq(&self, _other: &Self) -> bool {
+		true
+	}
+}
+
+impl PartialEq for MaxMessageSizeInBytes {
+	fn eq(&self, _other: &Self) -> bool {
+		true
+	}
 }
 
 pub struct AccountHandler;

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -73,6 +73,12 @@ impl PartialEq for MaxMessageSizeInBytes {
 	}
 }
 
+impl Clone for MaxMessageSizeInBytes {
+	fn clone(&self) -> Self {
+		MaxMessageSizeInBytes {}
+	}
+}
+
 pub struct AccountHandler;
 impl AccountProvider for AccountHandler {
 	type AccountId = u64;

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -59,24 +59,11 @@ parameter_types! {
 	pub const MaxMessageSizeInBytes: u32 = 100;
 }
 
-impl std::fmt::Debug for MaxMessagesPerBlock {
-	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("MaxMessagesPerBlock")
-			.field("v", &MaxMessagesPerBlock::get())
-			.finish()
-	}
-}
 impl std::fmt::Debug for MaxMessageSizeInBytes {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("MaxMessageSizeInBytes")
 			.field("v", &MaxMessageSizeInBytes::get())
 			.finish()
-	}
-}
-
-impl PartialEq for MaxMessagesPerBlock {
-	fn eq(&self, _other: &Self) -> bool {
-		true
 	}
 }
 

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -1,16 +1,22 @@
 use super::{mock::*, Event as MessageEvent};
 use crate::{BlockMessages, Config, Error, Message, Messages};
 use common_primitives::messages::{BlockPaginationRequest, MessageResponse, SchemaId};
-use frame_support::{assert_err, assert_noop, assert_ok};
+use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};
 use sp_std::vec::Vec;
 
 fn populate_messages(schema_id: SchemaId, message_per_block: Vec<u32>) {
 	let payload = Vec::from("{'fromId': 123, 'content': '232323114432'}".as_bytes());
 	let mut counter = 0;
 	for (idx, count) in message_per_block.iter().enumerate() {
-		let mut list = Vec::new();
+		let mut list = BoundedVec::default();
 		for _ in 0..*count {
-			list.push(Message { msa_id: 10, data: payload.clone(), index: counter, signer: 1 });
+			list.try_push(Message {
+				msa_id: 10,
+				data: payload.clone().try_into().unwrap(),
+				index: counter,
+				signer: 1,
+			})
+			.unwrap();
 			counter += 1;
 		}
 		Messages::<Test>::insert(idx as u64, schema_id, list);

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -41,7 +41,7 @@ fn add_message_should_store_message_on_temp_storage() {
 		));
 
 		// assert
-		let list = BlockMessages::<Test>::get();
+		let list = BlockMessages::<Test>::get().into_inner();
 		assert_eq!(list.len(), 2);
 
 		assert_eq!(
@@ -49,7 +49,7 @@ fn add_message_should_store_message_on_temp_storage() {
 			(
 				Message {
 					msa_id: get_msa_from_account(caller_1),
-					data: message_payload_1.clone(),
+					data: message_payload_1.clone().try_into().unwrap(),
 					index: 0,
 					signer: caller_1
 				},
@@ -62,7 +62,7 @@ fn add_message_should_store_message_on_temp_storage() {
 			(
 				Message {
 					msa_id: get_msa_from_account(caller_2),
-					data: message_payload_2.clone(),
+					data: message_payload_2.clone().try_into().unwrap(),
 					index: 1,
 					signer: caller_2
 				},

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -1,19 +1,25 @@
 use codec::{Decode, Encode};
 use common_primitives::{messages::MessageResponse, msa::MessageSenderId};
+use frame_support::{traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
 
 #[derive(Default, Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
-pub struct Message<AccountId> {
-	pub data: Vec<u8>,           //  Serialized data in a user-defined schema format
-	pub signer: AccountId,       //  Signature of the signer
-	pub msa_id: MessageSenderId, //  Message source account id (the original sender)
-	pub index: u16,              //  Stores index of message in block to keep total order
+#[scale_info(skip_type_params(MaxDataSize))]
+pub struct Message<AccountId, MaxDataSize>
+where
+	MaxDataSize: Get<u32>,
+{
+	pub data: BoundedVec<u8, MaxDataSize>, //  Serialized data in a user-defined schema format
+	pub signer: AccountId,                 //  Signature of the signer
+	pub msa_id: MessageSenderId,           //  Message source account id (the original sender)
+	pub index: u16,                        //  Stores index of message in block to keep total order
 }
 
-impl<AccountId> Message<AccountId>
+impl<AccountId, MaxDataSize> Message<AccountId, MaxDataSize>
 where
 	AccountId: Clone,
+	MaxDataSize: Get<u32>,
 {
 	pub fn map_to_response<BlockNumber>(
 		&self,
@@ -24,7 +30,7 @@ where
 			index: self.index,
 			msa_id: self.msa_id,
 			block_number,
-			data: self.data.clone(),
+			data: self.data.clone().into_inner(),
 		}
 	}
 }

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -8,7 +8,7 @@ use sp_std::prelude::*;
 #[scale_info(skip_type_params(MaxDataSize))]
 pub struct Message<AccountId, MaxDataSize>
 where
-	MaxDataSize: Get<u32>,
+	MaxDataSize: Get<u32> + Clone,
 {
 	pub data: BoundedVec<u8, MaxDataSize>, //  Serialized data in a user-defined schema format
 	pub signer: AccountId,                 //  Signature of the signer
@@ -19,7 +19,7 @@ where
 impl<AccountId, MaxDataSize> Message<AccountId, MaxDataSize>
 where
 	AccountId: Clone,
-	MaxDataSize: Get<u32>,
+	MaxDataSize: Get<u32> + Clone,
 {
 	pub fn map_to_response<BlockNumber>(
 		&self,

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -461,6 +461,12 @@ parameter_types! {
 	pub const MaxMessageSizeInBytes: u32 = 1024 * 50; // 50K
 }
 
+impl Clone for MaxMessageSizeInBytes {
+	fn clone(&self) -> Self {
+		MaxMessageSizeInBytes {}
+	}
+}
+
 impl pallet_messages::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = pallet_messages::weights::SubstrateWeight<Runtime>;

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -457,7 +457,7 @@ impl pallet_collator_selection::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxMessagesPerBlock: u16 = 7000;
+	pub const MaxMessagesPerBlock: u32 = 7000;
 	pub const MaxMessageSizeInBytes: u32 = 1024 * 50; // 50K
 }
 


### PR DESCRIPTION
# Problem
Replace Vec with BoundedVec issue #53

# What
- replaced vec with BoundedVec
- fixed the tests

# Notes
- The issue was mostly due to using `u16` instead of `u32`. `Decode` Trait is only implemented for `Get<T : u32>`