### PR TITLE
Use parallel iteration for checking delegations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5971,6 +5971,7 @@ dependencies = [
  "jsonrpc-derive",
  "pallet-msa-runtime-api",
  "parity-scale-codec",
+ "rayon",
  "sp-api",
  "sp-blockchain",
  "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.18)",

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -59,3 +59,33 @@ pub struct KeyInfoResponse<AccountId, BlockNumber> {
 	pub nonce: u32,
 	pub expired: BlockNumber,
 }
+
+#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
+pub struct Delegator(pub MessageSenderId);
+
+impl From<MessageSenderId> for Delegator {
+	fn from(t: MessageSenderId) -> Self {
+		Delegator(t)
+	}
+}
+
+impl From<Delegator> for MessageSenderId {
+	fn from(t: Delegator) -> MessageSenderId {
+		t.0
+	}
+}
+
+#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
+pub struct Provider(pub MessageSenderId);
+
+impl From<MessageSenderId> for Provider {
+	fn from(t: MessageSenderId) -> Self {
+		Provider(t)
+	}
+}
+
+impl From<Provider> for MessageSenderId {
+	fn from(t: Provider) -> MessageSenderId {
+		t.0
+	}
+}

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -59,33 +59,3 @@ pub struct KeyInfoResponse<AccountId, BlockNumber> {
 	pub nonce: u32,
 	pub expired: BlockNumber,
 }
-
-#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
-pub struct Delegator(pub MessageSenderId);
-
-impl From<MessageSenderId> for Delegator {
-	fn from(t: MessageSenderId) -> Self {
-		Delegator(t)
-	}
-}
-
-impl From<Delegator> for MessageSenderId {
-	fn from(t: Delegator) -> MessageSenderId {
-		t.0
-	}
-}
-
-#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
-pub struct Provider(pub MessageSenderId);
-
-impl From<MessageSenderId> for Provider {
-	fn from(t: MessageSenderId) -> Self {
-		Provider(t)
-	}
-}
-
-impl From<Provider> for MessageSenderId {
-	fn from(t: Provider) -> MessageSenderId {
-		t.0
-	}
-}

--- a/pallets/msa/src/rpc/Cargo.toml
+++ b/pallets/msa/src/rpc/Cargo.toml
@@ -14,6 +14,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 jsonrpc-core = "18.0"
 jsonrpc-core-client = "18.0"
 jsonrpc-derive = "18.0"
+rayon = "1.5"
 
 # unfinished
 pallet-msa-runtime-api = {default-features = false, path = "../runtime-api" }

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -81,14 +81,13 @@ where
 		let at = BlockId::hash(self.client.info().best_hash);
 
 		let provider = Provider(provider_msa_id);
-		let tups = delegator_msa_ids
+
+		Ok(delegator_msa_ids
 			.par_iter()
 			.map(|&id| {
 				let delegator = Delegator(id);
 				(id, map_rpc_result(api.has_delegation(&at, delegator, provider)))
 			})
-			.collect();
-
-		Ok(tups)
+			.collect())
 	}
 }

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -28,7 +28,7 @@ pub trait MsaApi<BlockHash, AccountId, BlockNumber> {
 		&self,
 		delegator_msa_ids: Vec<MessageSenderId>,
 		provider_msa_id: MessageSenderId,
-	) -> Result<BTreeMap<MessageSenderId, bool>>;
+	) -> Result<Vec<(MessageSenderId, Result<bool>)>>;
 }
 
 /// A struct that implements the `MessagesApi`.

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -28,7 +28,7 @@ pub trait MsaApi<BlockHash, AccountId, BlockNumber> {
 		&self,
 		delegator_msa_ids: Vec<MessageSenderId>,
 		provider_msa_id: MessageSenderId,
-	) -> Result<Vec<(MessageSenderId, Result<bool>)>>;
+	) -> Result<Vec<(MessageSenderId, bool)>>;
 }
 
 /// A struct that implements the `MessagesApi`.
@@ -76,7 +76,7 @@ where
 		&self,
 		delegator_msa_ids: Vec<MessageSenderId>,
 		provider_msa_id: MessageSenderId,
-	) -> Result<Vec<(MessageSenderId, Result<bool>)>> {
+	) -> Result<Vec<(MessageSenderId, bool)>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
 
@@ -86,7 +86,7 @@ where
 			.par_iter()
 			.map(|&id| {
 				let delegator = Delegator(id);
-				(id, map_rpc_result(api.has_delegation(&at, delegator, provider)))
+				(id, map_rpc_result(api.has_delegation(&at, delegator, provider)).unwrap())
 			})
 			.collect())
 	}

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -1,15 +1,15 @@
 use codec::Codec;
 use common_primitives::{
-	msa::{KeyInfoResponse, MessageSenderId},
+	msa::{Delegator, KeyInfoResponse, MessageSenderId, Provider},
 	rpc::*,
 };
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use pallet_msa_runtime_api::MsaApi as MsaRuntimeApi;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
-use sp_std::collections::btree_map::BTreeMap;
 use std::sync::Arc;
 
 #[rpc]
@@ -76,9 +76,19 @@ where
 		&self,
 		delegator_msa_ids: Vec<MessageSenderId>,
 		provider_msa_id: MessageSenderId,
-	) -> Result<BTreeMap<MessageSenderId, bool>> {
+	) -> Result<Vec<(MessageSenderId, Result<bool>)>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
-		map_rpc_result(api.check_delegations(&at, delegator_msa_ids, provider_msa_id))
+
+		let provider = Provider(provider_msa_id);
+		let tups = delegator_msa_ids
+			.par_iter()
+			.map(|&id| {
+				let delegator = Delegator(id);
+				(id, map_rpc_result(api.has_delegation(&at, delegator, provider)))
+			})
+			.collect();
+
+		Ok(tups)
 	}
 }

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -5,7 +5,7 @@
 use codec::Codec;
 use common_primitives::msa::*;
 use frame_support::dispatch::DispatchError;
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::vec::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime file (the `runtime/src/lib.rs`)
@@ -18,6 +18,6 @@ sp_api::decl_runtime_apis! {
 
 		fn get_msa_id(key: AccountId) -> Result<Option<MessageSenderId>, DispatchError>;
 
-		fn check_delegations(delegator_msa_ids: Vec<MessageSenderId>, provider_msa_id: MessageSenderId) -> Result<BTreeMap<MessageSenderId, bool>, DispatchError>;
+		fn has_delegation(delegator: Delegator, provider: Provider) -> Result<bool, DispatchError>;
 	}
 }

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -17,7 +17,6 @@ use sp_runtime::{
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature,
 };
-use sp_std::collections::btree_map::BTreeMap;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -695,14 +694,8 @@ impl_runtime_apis! {
 			Ok(Msa::get_owner_of(&key))
 		}
 
-		fn check_delegations(delegator_msa_ids: Vec<MessageSenderId>, provider_msa_id: MessageSenderId) -> Result<BTreeMap<MessageSenderId, bool>, DispatchError> {
-			let mut map = BTreeMap::new();
-			let provider = pallet_msa::types::Provider(provider_msa_id);
-			for id in delegator_msa_ids {
-				let delegator = pallet_msa::types::Delegator(id);
-				map.insert(id, Msa::get_provider_info_of(provider, delegator).is_some());
-			}
-			Ok(map)
+		fn has_delegation(delegator: Delegator, provider: Provider) -> Result<bool, DispatchError> {
+			Ok(Msa::get_provider_info_of(provider, delegator).is_some())
 		}
 	}
 


### PR DESCRIPTION
# Goal
The purpose of this PR is to replace the sequential iteration we were using to check delegations with a parallel iteration, courtesy of `Rayon`.

# Implementation
We iterate over the `delegator_msa_ids` like before, but instead of inserting the delegation boolean into a map, we return a Vec of `(MessageSenderId, bool)` tuples. This way, we don't have to worry about Substrate/Rust's map thread safety.

Closes [#130](https://github.com/LibertyDSNP/mrc/issues/130)