### PR TITLE
Don't run the build steps on PRs when only documentation is updated

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -4,6 +4,9 @@ concurrency:
   cancel-in-progress: true
 on:
   pull_request:
+    paths-ignore: # Skip running these steps if ONLY these files change
+      - 'designdocs/**'
+      - '**/*.md'
 jobs:
   tests:
     name: ${{ matrix.target }}


### PR DESCRIPTION
Small update to make it so that design doc PRs or just README changes don't need to run all the rust related actions. Lot faster to get design doc only PRs in.