### PR TITLE
Check expiration as a part of evaluating a valid delegation

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -130,6 +130,8 @@ pub mod pallet {
 		DelegationRevoked,
 		/// The operation was attempted with an unknown delegation
 		DelegationNotFound,
+		/// The operation was attempted with an expired delegation
+		DelegationExpired,
 	}
 
 	#[pallet::call]
@@ -401,6 +403,16 @@ impl<T: Config> Pallet<T> {
 			Ok(())
 		})?;
 
+		Ok(())
+	}
+
+	pub fn ensure_valid_delegation(provider: Provider, delegator: Delegator) -> DispatchResult {
+		let current_block = frame_system::Pallet::<T>::block_number();
+		let info = Self::get_provider_info_of(provider, delegator).ok_or(Error::<T>::DelegationNotFound)?;
+		if info.expired == T::BlockNumber::zero() {
+			return Ok(())
+		}
+		ensure!(info.expired >= current_block, Error::<T>::DelegationExpired);
 		Ok(())
 	}
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -408,7 +408,8 @@ impl<T: Config> Pallet<T> {
 
 	pub fn ensure_valid_delegation(provider: Provider, delegator: Delegator) -> DispatchResult {
 		let current_block = frame_system::Pallet::<T>::block_number();
-		let info = Self::get_provider_info_of(provider, delegator).ok_or(Error::<T>::DelegationNotFound)?;
+		let info = Self::get_provider_info_of(provider, delegator)
+			.ok_or(Error::<T>::DelegationNotFound)?;
 		if info.expired == T::BlockNumber::zero() {
 			return Ok(())
 		}

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -911,3 +911,52 @@ pub fn remove_delegation_by_provider_errors_when_no_delegator_msa_id() {
 		);
 	})
 }
+
+#[test]
+pub fn valid_delegation() {
+	new_test_ext().execute_with(|| {
+		let provider = Provider(1);
+		let delegator = Delegator(2);
+
+		assert_ok!(Msa::add_provider(provider, delegator));
+
+		System::set_block_number(System::block_number() + 1);
+
+		assert_ok!(Msa::ensure_valid_delegation(provider, delegator));
+	})
+}
+
+#[test]
+pub fn delegation_not_found() {
+	new_test_ext().execute_with(|| {
+		let provider = Provider(1);
+		let delegator = Delegator(2);
+
+		assert_noop!(
+			Msa::ensure_valid_delegation(provider, delegator),
+			Error::<Test>::DelegationNotFound);
+	})
+}
+
+#[test]
+pub fn delegation_expired() {
+	new_test_ext().execute_with(|| {
+		let provider = Provider(1);
+		let delegator = Delegator(2);
+
+		assert_ok!(Msa::add_provider(provider, delegator));
+
+		System::set_block_number(System::block_number() + 1);
+		assert_ok!(Msa::ensure_valid_delegation(provider, delegator));
+
+		// System::set_block_number(System::block_number() + 1);
+		assert_ok!(Msa::revoke_provider(provider, delegator));
+
+		System::set_block_number(System::block_number() + 1);
+
+		assert_noop!(
+			Msa::ensure_valid_delegation(provider, delegator),
+			Error::<Test>::DelegationExpired
+		);
+	})
+}

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -934,7 +934,8 @@ pub fn delegation_not_found() {
 
 		assert_noop!(
 			Msa::ensure_valid_delegation(provider, delegator),
-			Error::<Test>::DelegationNotFound);
+			Error::<Test>::DelegationNotFound
+		);
 	})
 }
 

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -950,7 +950,6 @@ pub fn delegation_expired() {
 		System::set_block_number(System::block_number() + 1);
 		assert_ok!(Msa::ensure_valid_delegation(provider, delegator));
 
-		// System::set_block_number(System::block_number() + 1);
 		assert_ok!(Msa::revoke_provider(provider, delegator));
 
 		System::set_block_number(System::block_number() + 1);

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -695,7 +695,10 @@ impl_runtime_apis! {
 		}
 
 		fn has_delegation(delegator: Delegator, provider: Provider) -> Result<bool, DispatchError> {
-			Ok(Msa::get_provider_info_of(provider, delegator).is_some())
+			match Msa::ensure_valid_delegation(provider, delegator) {
+				Ok(_) => Ok(true),
+				Err(_) => Err(sp_runtime::DispatchError::Other("Invalid Delegation")),
+			}
 		}
 	}
 


### PR DESCRIPTION
# Goal
The purpose of this PR is to introduce a check for a delegation's expiration as a part of evaluating delegation validity.

# Implementation
A provider's expiration is set at the time of revocation. When a delegation is queried for validity, we check to make sure that the expiration is greater than the current block. If it is, then the delegation has not expired (yet).