### PR TITLE
Switch to a positive test for rust files on a per job level

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -4,9 +4,6 @@ concurrency:
   cancel-in-progress: true
 on:
   pull_request:
-    paths-ignore: # Skip running these steps if ONLY these files change
-      - 'designdocs/**'
-      - '**/*.md'
 jobs:
   tests:
     name: ${{ matrix.target }}
@@ -29,14 +26,33 @@ jobs:
           df -h
       - name: Check out code
         uses: actions/checkout@v3
+
+      # Skip individual steps if only certain files changed
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/*.hbs'
+              - '.rustfmt.toml'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'ci/build.sh'
+              - 'scripts/**.sh'
+              - '.dockerignore'
+              - 'Dockerfile'
       - name: Install latest nightly
+        if: ${{ steps.filter.outputs.rust == 'true' }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           default: true
       - name: Cache
+        if: ${{ steps.filter.outputs.rust == 'true' }}
         uses: Swatinem/rust-cache@v1
       - name: Run tests
+        if: ${{ steps.filter.outputs.rust == 'true' }}
         run: ./ci/build.sh
         env:
           TARGET: ${{ matrix.target }}


### PR DESCRIPTION
#142 Did not work as desired from the perspective of the GitHub PR checks.

This switches from skipping the workflow to just skipping the steps. It can also be extended to support other positive filters on per-step basis.

Action used: https://github.com/marketplace/actions/paths-changes-filter