### PR TITLE
add delegator msa_id to message for delegated message publish

### DIFF
--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -15,9 +15,10 @@ use utils::*;
 pub struct MessageResponse<AccountId, BlockNumber> {
 	#[cfg_attr(feature = "std", serde(with = "as_hex"))]
 	pub data: Vec<u8>, //  Serialized data in a user-defined schema format
-	pub signer: AccountId,       //  Signature of the signer
-	pub msa_id: MessageSenderId, //  Message source account id (the original sender)
-	pub index: u16,              // index in block to get total order
+	pub signer: AccountId,                     //  Signature of the signer
+	pub sender_msa_id: MessageSenderId,        //  Message source account id (the original sender)
+	pub on_behalf_of: Option<MessageSenderId>, //  Message source account id (the original message producer)
+	pub index: u16,                            // index in block to get total order
 	pub block_number: BlockNumber,
 }
 

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -174,7 +174,8 @@ pub mod pallet {
 					data: message.try_into().unwrap(), // size is checked on top of extrinsic
 					signer: key,
 					index: current_size,
-					msa_id: message_sender_msa,
+					sender_msa_id: message_sender_msa,
+					on_behalf_of,
 				};
 				existing_messages
 					.try_push((m, schema_id))

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -14,7 +14,8 @@ fn populate_messages(schema_id: SchemaId, message_per_block: Vec<u32>) {
 		let mut list = BoundedVec::default();
 		for _ in 0..*count {
 			list.try_push(Message {
-				msa_id: 10,
+				sender_msa_id: 10,
+				on_behalf_of: None,
 				data: payload.clone().try_into().unwrap(),
 				index: counter,
 				signer: 1,
@@ -59,7 +60,8 @@ fn add_message_should_store_message_on_temp_storage() {
 			list[0],
 			(
 				Message {
-					msa_id: get_msa_from_account(caller_1),
+					sender_msa_id: get_msa_from_account(caller_1),
+					on_behalf_of: None,
 					data: message_payload_1.clone().try_into().unwrap(),
 					index: 0,
 					signer: caller_1
@@ -72,7 +74,8 @@ fn add_message_should_store_message_on_temp_storage() {
 			list[1],
 			(
 				Message {
-					msa_id: get_msa_from_account(caller_2),
+					sender_msa_id: get_msa_from_account(caller_2),
+					on_behalf_of: None,
 					data: message_payload_2.clone().try_into().unwrap(),
 					index: 1,
 					signer: caller_2
@@ -245,7 +248,8 @@ fn get_messages_by_schema_with_valid_request_should_return_paginated() {
 		assert_eq!(
 			pagination_response.content[0],
 			MessageResponse {
-				msa_id: 10,
+				sender_msa_id: 10,
+				on_behalf_of: None,
 				data: Vec::from("{'fromId': 123, 'content': '232323114432'}".as_bytes()),
 				index: from_index as u16,
 				signer: 1,
@@ -393,7 +397,8 @@ fn add_message_via_valid_delegate_should_pass() {
 			list[0],
 			(
 				Message {
-					msa_id: get_msa_from_account(caller_1),
+					sender_msa_id: get_msa_from_account(caller_1),
+					on_behalf_of: Some(message_producer),
 					data: message_payload_1.clone().try_into().unwrap(),
 					index: 0,
 					signer: caller_1
@@ -406,7 +411,8 @@ fn add_message_via_valid_delegate_should_pass() {
 			list[1],
 			(
 				Message {
-					msa_id: get_msa_from_account(caller_2),
+					sender_msa_id: get_msa_from_account(caller_2),
+					on_behalf_of: Some(message_producer),
 					data: message_payload_2.clone().try_into().unwrap(),
 					index: 1,
 					signer: caller_2

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -12,7 +12,8 @@ where
 {
 	pub data: BoundedVec<u8, MaxDataSize>, //  Serialized data in a user-defined schema format
 	pub signer: AccountId,                 //  Signature of the signer
-	pub msa_id: MessageSenderId,           //  Message source account id (the original sender)
+	pub sender_msa_id: MessageSenderId,    //  Message source account id (the original sender)
+	pub on_behalf_of: Option<MessageSenderId>, //  Message source account id (the message producer).
 	pub index: u16,                        //  Stores index of message in block to keep total order
 }
 
@@ -28,7 +29,8 @@ where
 		MessageResponse {
 			signer: self.signer.clone(),
 			index: self.index,
-			msa_id: self.msa_id,
+			sender_msa_id: self.sender_msa_id,
+			on_behalf_of: self.on_behalf_of,
 			block_number,
 			data: self.data.clone().into_inner(),
 		}


### PR DESCRIPTION
A bug was reported #156 
- MRC message should include if message was stored on behalf of a delegator
- Add a field to message type to hold that information as optional (i.e. if actually message was sent on behalf or not)
- Update unit tests and logic to refer to sender_msa_id as the id of actualy sender of message (could be a provider or delegator) and on_behalf_of as msa_id if the message is sent to publish on behalf of a user

pair: @enddynayn  verify if the intention behind the bug is what being addressed here 