### PR TITLE
Documentation for Schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 
 RUN apt-get install jq -y
 
-COPY ./target/release/mrc-collator ./target/release/
+COPY target/release/mrc-collator ./target/release/
 
 RUN ls ./target/release
 

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -1,3 +1,46 @@
+//! # Schemas Pallet
+//!
+//! The Schemas pallet provides functionality for handling schemas.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//!
+//! This pallet provides an on chain repository for schemas, thereby allowing participants of the
+//! network to flexibly interact and exchange messages with each other without facing the challenge
+//! of sharing, managing and validating messages as well as schemas between them.
+//!
+//! > NOTE: In this pallet we define the payload format that is used in Messages Pallet.
+//!
+//! The Schema pallet provides functions for:
+//!
+//! - Registering a new schema.
+//! - Setting maximum schema format size by governance.
+//! - Retrieving latest registered schema id.
+//! - Retrieving schemas by their id.
+//!
+//!
+//! ### Terminology
+//!
+//! - **Schema:** A data structure that defines the payload format of any Message that is going to
+//!   stored with that schema.
+//!
+//! - **Schema Format:** Serialization/Deserialization details of the schema
+//!
+//! - **Schema Format Type:** The type of the following Serialization/Deserialization. It can be
+//!   Avro, Parquet or ...
+//!
+//! ### Dispatchable Functions
+//!
+//! - `register_schema` - Registers a new schema after some initial validation.
+//! - `set_max_schema_format_bytes` - Sets the maximum schemas format size (Bytes) by governance.
+//!
+//! ## Genesis config
+//!
+//! The Schemas pallet depends on the [`GenesisConfig`].
+//!
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core;
@@ -26,18 +69,21 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
+		/// The overarching event type.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
-		// Maximum length of Schema field name
+		/// Minimum length of Schema format size in bytes
 		#[pallet::constant]
 		type MinSchemaFormatSizeBytes: Get<u32>;
 
-		// Maximum length of Schema Bounded Vec
+		/// Maximum length of Schema  format Bounded Vec
 		#[pallet::constant]
 		type SchemaFormatMaxBytesBoundedVecLimit: Get<u32>;
 
-		// Maximum number of schemas that can be registered
+		/// Maximum number of schemas that can be registered
 		#[pallet::constant]
 		type MaxSchemaRegistrations: Get<SchemaId>;
 	}
@@ -45,8 +91,10 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Emitted when a schemas is registered. [who, schemas id]
+		/// Emitted when a schema is registered. [who, schemas id]
 		SchemaRegistered(T::AccountId, SchemaId),
+
+		/// Emitted when maximum size for schema format is changed.
 		SchemaMaxSizeChanged(u32),
 	}
 
@@ -174,7 +222,7 @@ pub mod pallet {
 		}
 
 		pub fn get_schema_by_id(schema_id: SchemaId) -> Option<SchemaResponse> {
-			// TODO: This will eventually be a strut with other properties. Currently it is just the format
+			// TODO: This will eventually be a struct with other properties. Currently it is just the format
 			if let Some(format) = Self::get_schema(schema_id) {
 				// this should get a BoundedVec out
 				let format_vec = format.into_inner();

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -166,6 +166,30 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+
+		/// Adds a given schema to storage. The schema in question must be of length
+		/// between the min and max format size allowed for schemas (see pallet
+		/// constants above). If the pallet's maximum schema limit has been
+		/// fulfilled by the time this extrinsic is called, a TooManySchemas error
+		/// will be thrown. 
+		/// 
+		/// @param 	origin	OriginFor<T:Config> 					The originator of the transaction
+		///
+		/// @return         DispatchResult                The result of dispatching
+		///                                               this extrinsic to the
+		///                                               Substrate runtime.
+		///
+		/// @throws         LessThanMinSchemaFormatBytes  The schema's length is
+		///                                               less than the minimum
+		///                                               schema length
+		/// @throws         ExceedsMaxSchemaFormatBytes   The schema's length is
+		///                                               greater than the maximum
+		///                                               schema length
+		/// @throws         TooManySchemas                The maximum number of
+		/// 																							schemas has been met
+		/// @throws         SchemaCountOverflow           The schema count has
+		///                                               exceeded its bounds
+		/// 
 		#[pallet::weight(< T as Config >::WeightInfo::register_schema(schema.len() as u32, 1000))]
 		pub fn register_schema(
 			origin: OriginFor<T>,

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -12,7 +12,7 @@
 //! network to flexibly interact and exchange messages with each other without facing the challenge
 //! of sharing, managing and validating messages as well as schemas between them.
 //!
-//! > NOTE: In this pallet we define the payload format that is used in Messages Pallet.
+//! <b>NOTE</b>: In this pallet we define the <b>payload</b> format that is used in <a href="../pallet_messages/index.html">Messages Pallet</a>.
 //!
 //! The Schema pallet provides functions for:
 //!

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -166,14 +166,13 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-
 		/// Adds a given schema to storage. The schema in question must be of length
 		/// between the min and max format size allowed for schemas (see pallet
 		/// constants above). If the pallet's maximum schema limit has been
 		/// fulfilled by the time this extrinsic is called, a TooManySchemas error
-		/// will be thrown. 
-		/// 
-		/// @param 	origin	OriginFor<T:Config> 					The originator of the transaction
+		/// will be thrown.
+		///
+		/// @param 	origin	OriginFor<T:Config>           The originator of the transaction
 		///
 		/// @return         DispatchResult                The result of dispatching
 		///                                               this extrinsic to the
@@ -186,10 +185,10 @@ pub mod pallet {
 		///                                               greater than the maximum
 		///                                               schema length
 		/// @throws         TooManySchemas                The maximum number of
-		/// 																							schemas has been met
+		///                                               schemas has been met
 		/// @throws         SchemaCountOverflow           The schema count has
 		///                                               exceeded its bounds
-		/// 
+		///
 		#[pallet::weight(< T as Config >::WeightInfo::register_schema(schema.len() as u32, 1000))]
 		pub fn register_schema(
 			origin: OriginFor<T>,

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -26,14 +26,22 @@ impl From<Error> for i64 {
 	}
 }
 
+/// MRC Schema API
 #[rpc]
 pub trait SchemasApi<BlockHash> {
+	/// returns the latest registered schema id
+	///
+	/// `at`: block number to query. If it's `None` will use the latest block number.
+	///
+	/// Returns schema id.
 	#[rpc(name = "schemas_getLatestSchemaId")]
 	fn get_latest_schema_id(&self, at: Option<BlockHash>) -> Result<u16>;
 
+	/// retrieving schema by schema id
 	#[rpc(name = "schemas_getBySchemaId")]
 	fn get_by_schema_id(&self, schema_id: SchemaId) -> Result<Option<SchemaResponse>>;
 
+	/// validates a schema format and returns `true` if the format is correct.
 	#[rpc(name = "schemas_checkSchemaValidity")]
 	fn check_schema_validity(&self, at: Option<BlockHash>, format: Vec<u8>) -> Result<bool>;
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to document the Schemas Pallet.

# Contents
This branch contains docs for:
- Overview
- Config enums
- `register_schema` extrinsic
- `SchemasApi` trait