### PR TITLE
Documentation Day Renaming: Message Source Id and Message.provider_key

### DIFF
--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -1,4 +1,4 @@
-use crate::msa::MessageSenderId;
+use crate::msa::MessageSourceId;
 #[cfg(feature = "std")]
 use crate::utils;
 use codec::{Decode, Encode};
@@ -19,8 +19,8 @@ pub struct MessageResponse<AccountId, BlockNumber> {
 	pub payload: Vec<u8>,
 	/// Signature of the signer.
 	pub signer: AccountId,
-	/// Message source account id (the original sender).
-	pub msa_id: MessageSenderId,
+	/// Message source account id (the original source).
+	pub msa_id: MessageSourceId,
 	/// Index in block to get total order
 	pub index: u16,
 	/// Block-number for which the message was stored.

--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -17,8 +17,8 @@ pub struct MessageResponse<AccountId, BlockNumber> {
 	#[cfg_attr(feature = "std", serde(with = "as_hex"))]
 	/// Serialized data in a user-defined schema format.
 	pub payload: Vec<u8>,
-	/// Signature of the signer.
-	pub signer: AccountId,
+	/// The public key of the provider and the signer of the transaction.
+	pub provider_key: AccountId,
 	/// Message source account id (the original source).
 	pub msa_id: MessageSourceId,
 	/// Index in block to get total order

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -5,26 +5,26 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::DispatchError;
 
-pub type MessageSenderId = u64;
+pub type MessageSourceId = u64;
 
 #[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
-pub struct Delegator(pub MessageSenderId);
+pub struct Delegator(pub MessageSourceId);
 
-impl From<MessageSenderId> for Delegator {
-	fn from(t: MessageSenderId) -> Self {
+impl From<MessageSourceId> for Delegator {
+	fn from(t: MessageSourceId) -> Self {
 		Delegator(t)
 	}
 }
 
-impl From<Delegator> for MessageSenderId {
-	fn from(t: Delegator) -> MessageSenderId {
+impl From<Delegator> for MessageSourceId {
+	fn from(t: Delegator) -> MessageSourceId {
 		t.0
 	}
 }
 
 #[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Default, MaxEncodedLen)]
 pub struct KeyInfo<BlockNumber> {
-	pub msa_id: MessageSenderId,
+	pub msa_id: MessageSourceId,
 	pub nonce: u32,
 	pub expired: BlockNumber,
 }
@@ -50,16 +50,16 @@ pub struct ProviderInfo<BlockNumber> {
 }
 
 #[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
-pub struct Provider(pub MessageSenderId);
+pub struct Provider(pub MessageSourceId);
 
-impl From<MessageSenderId> for Provider {
-	fn from(t: MessageSenderId) -> Self {
+impl From<MessageSourceId> for Provider {
+	fn from(t: MessageSourceId) -> Self {
 		Provider(t)
 	}
 }
 
-impl From<Provider> for MessageSenderId {
-	fn from(t: Provider) -> MessageSenderId {
+impl From<Provider> for MessageSourceId {
+	fn from(t: Provider) -> MessageSourceId {
 		t.0
 	}
 }
@@ -67,7 +67,7 @@ impl From<Provider> for MessageSenderId {
 pub trait AccountProvider {
 	type AccountId;
 	type BlockNumber;
-	fn get_msa_id(key: &Self::AccountId) -> Option<MessageSenderId>;
+	fn get_msa_id(key: &Self::AccountId) -> Option<MessageSourceId>;
 	fn get_provider_info_of(
 		provider: Provider,
 		delegator: Delegator,
@@ -83,7 +83,7 @@ pub trait AccountProvider {
 #[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Default, MaxEncodedLen)]
 pub struct KeyInfoResponse<AccountId, BlockNumber> {
 	pub key: AccountId,
-	pub msa_id: MessageSenderId,
+	pub msa_id: MessageSourceId,
 	pub nonce: u32,
 	pub expired: BlockNumber,
 }

--- a/designdocs/MESSAGE_STORAGE.md
+++ b/designdocs/MESSAGE_STORAGE.md
@@ -47,8 +47,8 @@ using [StorageDoubleMap](https://docs.substrate.io/rustdocs/latest/frame_support
 Following is a proposed data structure for storing a Message on chain.
 ```rust
 pub struct Message<AccountId> {
-    pub data: Vec<u8>,		    //  Serialized data in a user-defined schemas format
-    pub signer: AccountId,	    //  Signature of the signer
+    pub payload: Vec<u8>,		    //  Serialized data in a user-defined schemas format
+    pub provider_key: AccountId,	    //  Signature of the signer
     pub msa_id: u64,                //  Message source account id (the original source of the message)
     pub index: u16,		    //  Stores index of message in block to keep total order
 }

--- a/designdocs/MESSAGE_STORAGE.md
+++ b/designdocs/MESSAGE_STORAGE.md
@@ -49,7 +49,7 @@ Following is a proposed data structure for storing a Message on chain.
 pub struct Message<AccountId> {
     pub data: Vec<u8>,		    //  Serialized data in a user-defined schemas format
     pub signer: AccountId,	    //  Signature of the signer
-    pub msa_id: u64,                //  Message source account id (the original sender)
+    pub msa_id: u64,                //  Message source account id (the original source of the message)
     pub index: u16,		    //  Stores index of message in block to keep total order
 }
 ```

--- a/js/rpc/definitions/messages.js
+++ b/js/rpc/definitions/messages.js
@@ -27,7 +27,7 @@ export default {
     MessageResponse: {
       payload: "Vec<u8>", //  Serialized data in a user-defined schema format
       signer: "AccountId", //  Signature of the signer
-      msa_id: "MessageSenderId", //  Message source account id (the original sender)
+      msa_id: "MessageSourceId", //  Message source account id (the original source)
       index: "u16", // index in block to get total order
       block_number: "BlockNumber",
     },

--- a/js/rpc/definitions/messages.js
+++ b/js/rpc/definitions/messages.js
@@ -26,7 +26,7 @@ export default {
     },
     MessageResponse: {
       payload: "Vec<u8>", //  Serialized data in a user-defined schema format
-      signer: "AccountId", //  Signature of the signer
+      provider_key: "AccountId", //  Public key of the provider and signer of the transaction
       msa_id: "MessageSourceId", //  Message source account id (the original source)
       index: "u16", // index in block to get total order
       block_number: "BlockNumber",

--- a/js/rpc/definitions/msa.js
+++ b/js/rpc/definitions/msa.js
@@ -9,14 +9,14 @@ export default {
             type: "AccountId",
           },
         ],
-        type: "Option<MessageSenderId>",
+        type: "Option<MessageSourceId>",
       },
       getMsaKeys: {
         description: "Fetch Keys for an MSA Id",
         params: [
           {
             name: "msa_id",
-            type: "MessageSenderId",
+            type: "MessageSourceId",
           },
         ],
         type: "Vec<KeyInfoResponse>",
@@ -26,22 +26,22 @@ export default {
         params: [
           {
             name: "delegator_msa_ids",
-            type: "Vec<MessageSenderId>",
+            type: "Vec<MessageSourceId>",
           },
           {
             name: "provider_msa_id",
-            type: "MessageSenderId",
+            type: "MessageSourceId",
           },
         ],
-        type: "Vec<(MessageSenderId, bool)>",
+        type: "Vec<(MessageSourceId, bool)>",
       },
     },
   },
   types: {
-    MessageSenderId: "u64",
+    MessageSourceId: "u64",
     KeyInfoResponse: {
       key: "AccountId",
-      msaId: "MessageSenderId",
+      msaId: "MessageSourceId",
       nonce: "u32",
       expired: "BlockNumber",
     },

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -195,7 +195,7 @@ pub mod pallet {
 				let payload_size = payload.len();
 				let m = Message {
 					payload: payload.try_into().unwrap(), // size is checked on top of extrinsic
-					signer: provider_key,
+					provider_key,
 					index: current_size,
 					msa_id: message_source_id,
 				};

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -59,7 +59,7 @@ use common_primitives::{messages::*, schema::*};
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use common_primitives::msa::{AccountProvider, Delegator, MessageSenderId, Provider};
+	use common_primitives::msa::{AccountProvider, Delegator, MessageSourceId, Provider};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
@@ -160,7 +160,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::add(payload.len() as u32, 1_000))]
 		pub fn add(
 			origin: OriginFor<T>,
-			on_behalf_of: Option<MessageSenderId>,
+			on_behalf_of: Option<MessageSourceId>,
 			schema_id: SchemaId,
 			payload: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
@@ -174,7 +174,7 @@ pub mod pallet {
 			let info = T::AccountProvider::ensure_valid_msa_key(&key)
 				.map_err(|_| Error::<T>::InvalidMessageSourceAccount)?;
 
-			let message_sender_msa = match on_behalf_of {
+			let message_source_id = match on_behalf_of {
 				Some(delegator) => {
 					T::AccountProvider::ensure_valid_delegation(
 						Provider(info.msa_id),
@@ -197,7 +197,7 @@ pub mod pallet {
 					payload: payload.try_into().unwrap(), // size is checked on top of extrinsic
 					signer: key,
 					index: current_size,
-					msa_id: message_sender_msa,
+					msa_id: message_source_id,
 				};
 				existing_messages
 					.try_push((m, schema_id))

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -1,6 +1,6 @@
 use crate as pallet_messages;
 use common_primitives::msa::{
-	AccountProvider, Delegator, KeyInfo, MessageSenderId, Provider, ProviderInfo,
+	AccountProvider, Delegator, KeyInfo, MessageSourceId, Provider, ProviderInfo,
 };
 use frame_support::{
 	dispatch::DispatchResult,
@@ -87,14 +87,14 @@ pub struct AccountHandler;
 impl AccountProvider for AccountHandler {
 	type AccountId = u64;
 	type BlockNumber = u64;
-	fn get_msa_id(key: &Self::AccountId) -> Option<MessageSenderId> {
+	fn get_msa_id(key: &Self::AccountId) -> Option<MessageSourceId> {
 		if *key == 1000 {
 			return None
 		}
 		if *key == 2000 {
-			return Some(2000 as MessageSenderId)
+			return Some(2000 as MessageSourceId)
 		}
-		Some(get_msa_from_account(*key) as MessageSenderId)
+		Some(get_msa_from_account(*key) as MessageSourceId)
 	}
 	fn get_provider_info_of(
 		provider: Provider,

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -17,7 +17,7 @@ fn populate_messages(schema_id: SchemaId, message_per_block: Vec<u32>) {
 				msa_id: 10,
 				payload: payload.clone().try_into().unwrap(),
 				index: counter,
-				signer: 1,
+				provider_key: 1,
 			})
 			.unwrap();
 			counter += 1;
@@ -62,7 +62,7 @@ fn add_message_should_store_message_on_temp_storage() {
 					msa_id: get_msa_from_account(caller_1),
 					payload: message_payload_1.clone().try_into().unwrap(),
 					index: 0,
-					signer: caller_1
+					provider_key: caller_1
 				},
 				schema_id_1
 			)
@@ -75,7 +75,7 @@ fn add_message_should_store_message_on_temp_storage() {
 					msa_id: get_msa_from_account(caller_2),
 					payload: message_payload_2.clone().try_into().unwrap(),
 					index: 1,
-					signer: caller_2
+					provider_key: caller_2
 				},
 				schema_id_2
 			)
@@ -248,7 +248,7 @@ fn get_messages_by_schema_with_valid_request_should_return_paginated() {
 				msa_id: 10,
 				payload: Vec::from("{'fromId': 123, 'content': '232323114432'}".as_bytes()),
 				index: from_index as u16,
-				signer: 1,
+				provider_key: 1,
 				block_number: 0
 			}
 		);
@@ -396,7 +396,7 @@ fn add_message_via_valid_delegate_should_pass() {
 					msa_id: message_producer,
 					payload: message_payload_1.clone().try_into().unwrap(),
 					index: 0,
-					signer: caller_1
+					provider_key: caller_1
 				},
 				schema_id_1
 			)
@@ -409,7 +409,7 @@ fn add_message_via_valid_delegate_should_pass() {
 					msa_id: message_producer,
 					payload: message_payload_2.clone().try_into().unwrap(),
 					index: 1,
-					signer: caller_2
+					provider_key: caller_2
 				},
 				schema_id_2
 			)

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -13,8 +13,8 @@ where
 {
 	///  Serialized data in a user-defined schema format
 	pub payload: BoundedVec<u8, MaxDataSize>,
-	///  Signature of the signer
-	pub signer: AccountId,
+	///  Public key of the provider that signed the transaction
+	pub provider_key: AccountId,
 	///  Message source account id (the original source)
 	pub msa_id: MessageSourceId,
 	///  Stores index of message in block to keep total order
@@ -32,7 +32,7 @@ where
 		block_number: BlockNumber,
 	) -> MessageResponse<AccountId, BlockNumber> {
 		MessageResponse {
-			signer: self.signer.clone(),
+			provider_key: self.signer.clone(),
 			index: self.index,
 			msa_id: self.msa_id,
 			block_number,

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use common_primitives::{messages::MessageResponse, msa::MessageSenderId};
+use common_primitives::{messages::MessageResponse, msa::MessageSourceId};
 use frame_support::{traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
@@ -15,8 +15,8 @@ where
 	pub payload: BoundedVec<u8, MaxDataSize>,
 	///  Signature of the signer
 	pub signer: AccountId,
-	///  Message source account id (the original sender)
-	pub msa_id: MessageSenderId,
+	///  Message source account id (the original source)
+	pub msa_id: MessageSourceId,
 	///  Stores index of message in block to keep total order
 	pub index: u16,
 }

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -50,7 +50,7 @@ fn add_key_payload_and_signature<T: Config>() -> (AddKeyData, MultiSignature, T:
 	(add_key_payload, MultiSignature::Sr25519(signature.into()), acc.into())
 }
 
-fn create_account_with_msa_id<T: Config>(n: u32) -> (T::AccountId, MessageSenderId) {
+fn create_account_with_msa_id<T: Config>(n: u32) -> (T::AccountId, MessageSourceId) {
 	let provider = create_account::<T>("account", n);
 
 	assert_ok!(Msa::<T>::create(RawOrigin::Signed(provider.clone()).into()));

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -1,6 +1,6 @@
 use codec::Codec;
 use common_primitives::{
-	msa::{Delegator, KeyInfoResponse, MessageSenderId, Provider},
+	msa::{Delegator, KeyInfoResponse, MessageSourceId, Provider},
 	rpc::*,
 };
 use jsonrpc_core::Result;
@@ -17,18 +17,18 @@ pub trait MsaApi<BlockHash, AccountId, BlockNumber> {
 	#[rpc(name = "msa_getMsaKeys")]
 	fn get_msa_keys(
 		&self,
-		msa_id: MessageSenderId,
+		msa_id: MessageSourceId,
 	) -> Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>>;
 
 	#[rpc(name = "msa_getMsaId")]
-	fn get_msa_id(&self, key: AccountId) -> Result<Option<MessageSenderId>>;
+	fn get_msa_id(&self, key: AccountId) -> Result<Option<MessageSourceId>>;
 
 	#[rpc(name = "msa_checkDelegations")]
 	fn check_delegations(
 		&self,
-		delegator_msa_ids: Vec<MessageSenderId>,
-		provider_msa_id: MessageSenderId,
-	) -> Result<Vec<(MessageSenderId, bool)>>;
+		delegator_msa_ids: Vec<MessageSourceId>,
+		provider_msa_id: MessageSourceId,
+	) -> Result<Vec<(MessageSourceId, bool)>>;
 }
 
 /// A struct that implements the `MessagesApi`.
@@ -57,7 +57,7 @@ where
 {
 	fn get_msa_keys(
 		&self,
-		msa_id: MessageSenderId,
+		msa_id: MessageSourceId,
 	) -> Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
@@ -65,7 +65,7 @@ where
 		map_rpc_result(runtime_api_result)
 	}
 
-	fn get_msa_id(&self, key: AccountId) -> Result<Option<MessageSenderId>> {
+	fn get_msa_id(&self, key: AccountId) -> Result<Option<MessageSourceId>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
 		let runtime_api_result = api.get_msa_id(&at, key);
@@ -74,9 +74,9 @@ where
 
 	fn check_delegations(
 		&self,
-		delegator_msa_ids: Vec<MessageSenderId>,
-		provider_msa_id: MessageSenderId,
-	) -> Result<Vec<(MessageSenderId, bool)>> {
+		delegator_msa_ids: Vec<MessageSourceId>,
+		provider_msa_id: MessageSourceId,
+	) -> Result<Vec<(MessageSourceId, bool)>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
 

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -14,9 +14,9 @@ sp_api::decl_runtime_apis! {
 		AccountId: Codec,
 		BlockNumber: Codec,
 	{
-		fn get_msa_keys(msa_id: MessageSenderId) ->	Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>, DispatchError>;
+		fn get_msa_keys(msa_id: MessageSourceId) ->	Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>, DispatchError>;
 
-		fn get_msa_id(key: AccountId) -> Result<Option<MessageSenderId>, DispatchError>;
+		fn get_msa_id(key: AccountId) -> Result<Option<MessageSourceId>, DispatchError>;
 
 		fn has_delegation(delegator: Delegator, provider: Provider) -> Result<bool, DispatchError>;
 	}

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -1,19 +1,19 @@
 use super::*;
-pub use common_primitives::msa::{Delegator, KeyInfoResponse, MessageSenderId, Provider};
+pub use common_primitives::msa::{Delegator, KeyInfoResponse, MessageSourceId, Provider};
 use scale_info::TypeInfo;
 
 use codec::{Decode, Encode};
 
-pub const EMPTY_FUNCTION: fn(MessageSenderId) -> DispatchResult = |_| Ok(());
+pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 
 #[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq)]
 pub struct AddKeyData {
-	pub msa_id: MessageSenderId,
+	pub msa_id: MessageSourceId,
 	pub nonce: u32,
 }
 
 #[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq)]
 pub struct AddProvider {
-	pub authorized_msa_id: MessageSenderId,
+	pub authorized_msa_id: MessageSourceId,
 	pub permission: u8,
 }

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -686,11 +686,11 @@ impl_runtime_apis! {
 	}
 
 	impl pallet_msa_runtime_api::MsaApi<Block, AccountId, BlockNumber> for Runtime {
-		fn get_msa_keys(msa_id: MessageSenderId) -> Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>, DispatchError> {
+		fn get_msa_keys(msa_id: MessageSourceId) -> Result<Vec<KeyInfoResponse<AccountId, BlockNumber>>, DispatchError> {
 			Ok(Msa::fetch_msa_keys(msa_id))
 		}
 
-		fn get_msa_id(key: AccountId) -> Result<Option<MessageSenderId>, DispatchError> {
+		fn get_msa_id(key: AccountId) -> Result<Option<MessageSourceId>, DispatchError> {
 			Ok(Msa::get_owner_of(&key))
 		}
 


### PR DESCRIPTION
Blocked pending merge of `doc/documentation_day_msa` into `doc/documentation_day` first.

- Rename type `MessageSenderId` -> `MessageSourceId`
- Rename Message field `sender` to `provider_key` for clarity