### PR TITLE
Clippy cleanup

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -31,6 +31,6 @@ case $TARGET in
 
   lint)
     cargo fmt -- --check
-    SKIP_WASM_BUILD=1 cargo clippy --all-targets
+    SKIP_WASM_BUILD=1 cargo clippy --all-targets  -- -A clippy::bool_assert_comparison
     ;;
 esac

--- a/common/helpers/src/avro.rs
+++ b/common/helpers/src/avro.rs
@@ -184,7 +184,7 @@ pub fn populate_schema_and_serialize(
 	for (field_name, field_value) in records.iter() {
 		record_list.put(field_name, field_value.clone());
 	}
-	let datum_res = to_avro_datum(&schema, record_list)?;
+	let datum_res = to_avro_datum(schema, record_list)?;
 	Ok(datum_res)
 }
 

--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -57,7 +57,7 @@ where
 		self.page_size > 0 &&
 			self.page_size <= Self::MAX_PAGE_SIZE &&
 			self.from_block < self.to_block &&
-			self.to_block.clone().sub(self.from_block.clone()) <=
+			self.to_block.sub(self.from_block) <=
 				BlockNumber::from(Self::MAX_BLOCK_RANGE)
 	}
 }

--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -57,8 +57,7 @@ where
 		self.page_size > 0 &&
 			self.page_size <= Self::MAX_PAGE_SIZE &&
 			self.from_block < self.to_block &&
-			self.to_block.sub(self.from_block) <=
-				BlockNumber::from(Self::MAX_BLOCK_RANGE)
+			self.to_block.sub(self.from_block) <= BlockNumber::from(Self::MAX_BLOCK_RANGE)
 	}
 }
 

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -47,7 +47,7 @@ impl<BlockNumber: Clone> KeyInfo<BlockNumber> {
 		key: AccountId,
 	) -> KeyInfoResponse<AccountId, BlockNumber> {
 		KeyInfoResponse {
-			key: key.clone(),
+			key,
 			msa_id: self.msa_id,
 			nonce: self.nonce,
 			expired: self.expired.clone(),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -265,7 +265,7 @@ pub fn run() -> Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
 					.map(|e| e.para_id)
-					.ok_or_else(|| "Could not find parachain ID in chain-spec.")?;
+					.ok_or("Could not find parachain ID in chain-spec.")?;
 
 				let polkadot_cli = RelayChainCli::new(
 					&config,

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -138,7 +138,7 @@ impl pallet_messages::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
+	let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	let mut ext = sp_io::TestExternalities::new(t);
 	ext.execute_with(|| System::set_block_number(1));
 	ext

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -60,7 +60,7 @@ fn add_message_should_store_message_on_temp_storage() {
 			(
 				Message {
 					msa_id: get_msa_from_account(caller_1),
-					payload: message_payload_1.clone().try_into().unwrap(),
+					payload: message_payload_1.try_into().unwrap(),
 					index: 0,
 					provider_key: caller_1
 				},
@@ -73,7 +73,7 @@ fn add_message_should_store_message_on_temp_storage() {
 			(
 				Message {
 					msa_id: get_msa_from_account(caller_2),
-					payload: message_payload_2.clone().try_into().unwrap(),
+					payload: message_payload_2.try_into().unwrap(),
 					index: 1,
 					provider_key: caller_2
 				},
@@ -92,7 +92,7 @@ fn add_message_with_too_large_message_should_panic() {
 		let message_payload_1 = Vec::from("{'fromId': 123, 'content': '232323114432'}{'fromId': 123, 'content': '232323114432'}{'fromId': 123, 'content': '232323114432'}".as_bytes());
 
 		// act
-		assert_noop!(MessagesPallet::add(Origin::signed(caller_1), None, schema_id_1, message_payload_1.clone()), Error::<Test>::ExceedsMaxMessagePayloadSizeBytes);
+		assert_noop!(MessagesPallet::add(Origin::signed(caller_1), None, schema_id_1, message_payload_1), Error::<Test>::ExceedsMaxMessagePayloadSizeBytes);
 	});
 }
 
@@ -113,7 +113,7 @@ fn add_message_with_invalid_msa_account_should_panic() {
 				Origin::signed(caller_1),
 				None,
 				schema_id_1,
-				message_payload_1.clone()
+				message_payload_1
 			),
 			Error::<Test>::InvalidMessageSourceAccount
 		);
@@ -142,7 +142,7 @@ fn add_message_with_maxed_out_storage_should_panic() {
 				Origin::signed(caller_1),
 				None,
 				schema_id_1,
-				message_payload_1.clone()
+				message_payload_1
 			),
 			Error::<Test>::TooManyMessagesInBlock
 		);
@@ -170,13 +170,13 @@ fn on_initialize_should_add_messages_into_storage_and_clean_temp() {
 			Origin::signed(caller_2),
 			None,
 			schema_id_1,
-			message_payload_1.clone()
+			message_payload_1
 		));
 		assert_ok!(MessagesPallet::add(
 			Origin::signed(caller_2),
 			None,
 			schema_id_2,
-			message_payload_2.clone()
+			message_payload_2
 		));
 
 		// act
@@ -199,8 +199,7 @@ fn on_initialize_should_add_messages_into_storage_and_clean_temp() {
 				block_number: current_block,
 				schema_id: schema_id_1,
 				count: 2
-			})
-			.into(),
+			}),
 		);
 
 		assert_eq!(
@@ -209,8 +208,7 @@ fn on_initialize_should_add_messages_into_storage_and_clean_temp() {
 				block_number: current_block,
 				schema_id: schema_id_2,
 				count: 1
-			})
-			.into(),
+			}),
 		);
 	});
 }
@@ -323,7 +321,7 @@ fn get_messages_by_schema_with_invalid_request_should_panic() {
 		let page_size = 30;
 		let from_index = 0;
 		let messages_per_block = vec![10, 0, 5, 2, 0, 3, 9];
-		populate_messages(schema_id, messages_per_block.clone());
+		populate_messages(schema_id, messages_per_block);
 		let request =
 			BlockPaginationRequest { page_size, from_block: 22, to_block: 15, from_index };
 
@@ -343,7 +341,7 @@ fn get_messages_by_schema_with_overflowing_input_should_panic() {
 		let page_size = 30;
 		let from_index = 0;
 		let messages_per_block = vec![10, 0, 5, 2, 0, 3, 9];
-		populate_messages(schema_id, messages_per_block.clone());
+		populate_messages(schema_id, messages_per_block);
 		let request = BlockPaginationRequest {
 			page_size,
 			from_block: 22_343_223_111,
@@ -394,7 +392,7 @@ fn add_message_via_valid_delegate_should_pass() {
 			(
 				Message {
 					msa_id: message_producer,
-					payload: message_payload_1.clone().try_into().unwrap(),
+					payload: message_payload_1.try_into().unwrap(),
 					index: 0,
 					provider_key: caller_1
 				},
@@ -407,7 +405,7 @@ fn add_message_via_valid_delegate_should_pass() {
 			(
 				Message {
 					msa_id: message_producer,
-					payload: message_payload_2.clone().try_into().unwrap(),
+					payload: message_payload_2.try_into().unwrap(),
 					index: 1,
 					provider_key: caller_2
 				},
@@ -431,7 +429,7 @@ fn add_message_via_non_delegate_should_fail() {
 				Origin::signed(message_provider),
 				Some(message_producer),
 				schema_id_1,
-				message_payload_1.clone()
+				message_payload_1
 			),
 			Error::<Test>::UnAuthorizedDelegate
 		);

--- a/pallets/messages/src/tests.rs
+++ b/pallets/messages/src/tests.rs
@@ -109,12 +109,7 @@ fn add_message_with_invalid_msa_account_should_panic() {
 
 		// act
 		assert_noop!(
-			MessagesPallet::add(
-				Origin::signed(caller_1),
-				None,
-				schema_id_1,
-				message_payload_1
-			),
+			MessagesPallet::add(Origin::signed(caller_1), None, schema_id_1, message_payload_1),
 			Error::<Test>::InvalidMessageSourceAccount
 		);
 	});
@@ -138,12 +133,7 @@ fn add_message_with_maxed_out_storage_should_panic() {
 			));
 		}
 		assert_noop!(
-			MessagesPallet::add(
-				Origin::signed(caller_1),
-				None,
-				schema_id_1,
-				message_payload_1
-			),
+			MessagesPallet::add(Origin::signed(caller_1), None, schema_id_1, message_payload_1),
 			Error::<Test>::TooManyMessagesInBlock
 		);
 	});

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -243,10 +243,10 @@ pub mod pallet {
 
 			let (_, _) =
 				Self::create_account(delegator_key.clone(), |new_msa_id| -> DispatchResult {
-					let _ = Self::add_provider(provider_msa_id.into(), new_msa_id.into())?;
+					Self::add_provider(provider_msa_id.into(), new_msa_id.into())?;
 
 					Self::deposit_event(Event::MsaCreated {
-						msa_id: new_msa_id.clone(),
+						msa_id: new_msa_id,
 						key: delegator_key.clone(),
 					});
 
@@ -291,11 +291,11 @@ pub mod pallet {
 				payload_authorized_msa_id,
 			)?;
 
-			let _ = Self::add_provider(provider_msa_id, delegator_msa_id)?;
+			Self::add_provider(provider_msa_id, delegator_msa_id)?;
 
 			Self::deposit_event(Event::ProviderAdded {
-				delegator: delegator_msa_id.into(),
-				provider: provider_msa_id.into(),
+				delegator: delegator_msa_id,
+				provider: provider_msa_id,
 			});
 
 			Ok(())
@@ -463,7 +463,7 @@ impl<T: Config> Pallet<T> {
 			ensure!(maybe_msa.is_none(), Error::<T>::DuplicatedKey);
 
 			*maybe_msa = Some(KeyInfo {
-				msa_id: msa_id.clone(),
+				msa_id,
 				expired: T::BlockNumber::default(),
 				nonce: Zero::zero(),
 			});
@@ -489,8 +489,8 @@ impl<T: Config> Pallet<T> {
 		provider_key: &T::AccountId,
 		authorized_msa_id: MessageSourceId,
 	) -> Result<(Provider, Delegator), DispatchError> {
-		let provider_msa_id = Self::ensure_valid_msa_key(&provider_key)?.msa_id;
-		let delegator_msa_id = Self::ensure_valid_msa_key(&delegator_key)?.msa_id;
+		let provider_msa_id = Self::ensure_valid_msa_key(provider_key)?.msa_id;
+		let delegator_msa_id = Self::ensure_valid_msa_key(delegator_key)?.msa_id;
 
 		ensure!(authorized_msa_id == delegator_msa_id, Error::<T>::UnauthorizedDelegator);
 
@@ -515,10 +515,10 @@ impl<T: Config> Pallet<T> {
 		signer: T::AccountId,
 		payload: Vec<u8>,
 	) -> DispatchResult {
-		let key = T::ConvertIntoAccountId32::convert(signer.clone());
+		let key = T::ConvertIntoAccountId32::convert(signer);
 		let wrapped_payload = wrap_binary_data(payload);
 		ensure!(
-			signature.verify(&wrapped_payload[..], &key.clone().into()),
+			signature.verify(&wrapped_payload[..], &key),
 			Error::<T>::InvalidSignature
 		);
 
@@ -674,14 +674,14 @@ impl<T: Config> AccountProvider for Pallet<T> {
 	}
 
 	fn ensure_valid_delegation(provider: Provider, delegation: Delegator) -> DispatchResult {
-		Ok(Self::ensure_valid_delegation(provider, delegation)?)
+		Self::ensure_valid_delegation(provider, delegation)
 	}
 
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn ensure_valid_msa_key(
 		key: &T::AccountId,
 	) -> Result<KeyInfo<Self::BlockNumber>, DispatchError> {
-		Ok(Self::ensure_valid_msa_key(key)?)
+		Self::ensure_valid_msa_key(key)
 	}
 
 	/// Since benchmarks are using regular runtime, we can not use mocking for this loosely bounded

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -462,11 +462,8 @@ impl<T: Config> Pallet<T> {
 		KeyInfoOf::<T>::try_mutate(key, |maybe_msa| {
 			ensure!(maybe_msa.is_none(), Error::<T>::DuplicatedKey);
 
-			*maybe_msa = Some(KeyInfo {
-				msa_id,
-				expired: T::BlockNumber::default(),
-				nonce: Zero::zero(),
-			});
+			*maybe_msa =
+				Some(KeyInfo { msa_id, expired: T::BlockNumber::default(), nonce: Zero::zero() });
 
 			// adding reverse lookup
 			<MsaKeysOf<T>>::try_mutate(msa_id, |key_list| {
@@ -517,10 +514,7 @@ impl<T: Config> Pallet<T> {
 	) -> DispatchResult {
 		let key = T::ConvertIntoAccountId32::convert(signer);
 		let wrapped_payload = wrap_binary_data(payload);
-		ensure!(
-			signature.verify(&wrapped_payload[..], &key),
-			Error::<T>::InvalidSignature
-		);
+		ensure!(signature.verify(&wrapped_payload[..], &key), Error::<T>::InvalidSignature);
 
 		Ok(())
 	}

--- a/pallets/msa/src/mock.rs
+++ b/pallets/msa/src/mock.rs
@@ -67,7 +67,7 @@ impl pallet_msa::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
+	let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	let mut ext = sp_io::TestExternalities::new(t);
 	ext.execute_with(|| System::set_block_number(1));
 	ext
@@ -78,7 +78,7 @@ pub fn test_public(n: u8) -> AccountId32 {
 }
 
 pub fn test_origin_signed(n: u8) -> Origin {
-	Origin::signed(test_public(n).into())
+	Origin::signed(test_public(n))
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -27,9 +27,7 @@ fn it_creates_an_msa_account() {
 
 		assert_eq!(Msa::get_identifier(), 1);
 
-		System::assert_last_event(
-			Event::MsaCreated { msa_id: 1, key: test_public(1) }.into(),
-		);
+		System::assert_last_event(Event::MsaCreated { msa_id: 1, key: test_public(1) }.into());
 	});
 }
 
@@ -843,10 +841,7 @@ pub fn remove_delegation_by_provider_happy_path() {
 		System::set_block_number(System::block_number() + 25);
 
 		// 5. assert_ok! fn as 2 to remove provider 1
-		assert_ok!(Msa::remove_delegation_by_provider(
-			Origin::signed(provider_key.into()),
-			2u64
-		));
+		assert_ok!(Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64));
 
 		// 6. verify that the provider is revoked
 		let provider_info = Msa::get_provider_info_of(Provider(1), Delegator(2));

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -28,7 +28,7 @@ fn it_creates_an_msa_account() {
 		assert_eq!(Msa::get_identifier(), 1);
 
 		System::assert_last_event(
-			Event::MsaCreated { msa_id: 1, key: test_public(1).into() }.into(),
+			Event::MsaCreated { msa_id: 1, key: test_public(1) }.into(),
 		);
 	});
 }
@@ -85,7 +85,7 @@ fn it_throws_error_when_key_verification_fails() {
 				test_origin_signed(1),
 				fake_account.into(),
 				signature,
-				add_new_key_data.clone()
+				add_new_key_data
 			),
 			Error::<Test>::AddKeySignatureVerificationFailed
 		);
@@ -101,7 +101,7 @@ fn it_throws_error_when_not_msa_owner() {
 		let account = key_pair.public();
 
 		let (new_msa_id, _) = Msa::create_account(account.into(), EMPTY_FUNCTION).unwrap();
-		assert_ok!(Msa::create_account(test_public(1).into(), EMPTY_FUNCTION));
+		assert_ok!(Msa::create_account(test_public(1), EMPTY_FUNCTION));
 
 		let new_account = key_pair_2.public();
 
@@ -115,7 +115,7 @@ fn it_throws_error_when_not_msa_owner() {
 				test_origin_signed(1),
 				new_account.into(),
 				signature,
-				add_new_key_data.clone()
+				add_new_key_data
 			),
 			Error::<Test>::NotMsaOwner
 		);
@@ -141,7 +141,7 @@ fn it_throws_error_when_for_duplicate_key() {
 				Origin::signed(new_account.into()),
 				new_account.into(),
 				signature,
-				add_new_key_data.clone()
+				add_new_key_data
 			),
 			Error::<Test>::DuplicatedKey
 		);
@@ -179,7 +179,7 @@ fn add_key_with_more_than_allowed_should_panic() {
 				Origin::signed(account.into()),
 				final_account.into(),
 				signature,
-				add_new_key_data.clone()
+				add_new_key_data
 			),
 			Error::<Test>::KeyLimitExceeded
 		);
@@ -208,7 +208,7 @@ fn add_key_with_valid_request_should_store_value_and_event() {
 			Origin::signed(account.into()),
 			new_key.into(),
 			signature,
-			add_new_key_data.clone(),
+			add_new_key_data,
 		));
 
 		// assert
@@ -231,7 +231,7 @@ fn it_revokes_msa_key_successfully() {
 
 		assert_eq!(info, Some(KeyInfo { msa_id: 2, expired: 1, nonce: 0 }));
 
-		System::assert_last_event(Event::KeyRevoked { key: test_public(2).into() }.into());
+		System::assert_last_event(Event::KeyRevoked { key: test_public(2) }.into());
 	})
 }
 
@@ -501,7 +501,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		let (key_pair_delegator, _) = sr25519::Pair::generate();
 		let delegator_account = key_pair_delegator.public();
 
-		let add_provider_payload = AddProvider { authorized_msa_id: 1u64.into(), permission: 0 };
+		let add_provider_payload = AddProvider { authorized_msa_id: 1u64, permission: 0 };
 		let encode_add_provider_data = wrap_binary_data(add_provider_payload.encode());
 
 		let signature: MultiSignature = key_pair_delegator.sign(&encode_add_provider_data).into();
@@ -511,9 +511,9 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		// act
 		assert_ok!(Msa::create_sponsored_account_with_delegation(
 			Origin::signed(provider_account.into()),
-			delegator_account.clone().into(),
-			signature.clone(),
-			add_provider_payload.clone()
+			delegator_account.into(),
+			signature,
+			add_provider_payload
 		));
 
 		// assert
@@ -528,7 +528,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		let provider_event = &events_occured.as_slice()[2];
 		assert_eq!(
 			created_event.event,
-			Event::MsaCreated { msa_id: 2u64.into(), key: delegator_account.into() }.into()
+			Event::MsaCreated { msa_id: 2u64, key: delegator_account.into() }.into()
 		);
 		assert_eq!(
 			provider_event.event,
@@ -548,7 +548,7 @@ fn create_sponsored_account_with_delegation_with_invalid_signature_should_fail()
 
 		let (signer_pair, _) = sr25519::Pair::generate();
 
-		let add_provider_payload = AddProvider { authorized_msa_id: 1u64.into(), permission: 0 };
+		let add_provider_payload = AddProvider { authorized_msa_id: 1u64, permission: 0 };
 		let encode_add_provider_data = wrap_binary_data(add_provider_payload.encode());
 
 		let signature: MultiSignature = signer_pair.sign(&encode_add_provider_data).into();
@@ -559,9 +559,9 @@ fn create_sponsored_account_with_delegation_with_invalid_signature_should_fail()
 		assert_noop!(
 			Msa::create_sponsored_account_with_delegation(
 				Origin::signed(provider_account.into()),
-				delegator_account.clone().into(),
-				signature.clone(),
-				add_provider_payload.clone()
+				delegator_account.into(),
+				signature,
+				add_provider_payload
 			),
 			Error::<Test>::InvalidSignature
 		);
@@ -578,7 +578,7 @@ pub fn create_sponsored_account_with_delegation_with_invalid_add_provider_should
 		let (key_pair_delegator, _) = sr25519::Pair::generate();
 		let delegator_account = key_pair_delegator.public();
 
-		let add_provider_payload = AddProvider { authorized_msa_id: 1u64.into(), permission: 0 };
+		let add_provider_payload = AddProvider { authorized_msa_id: 1u64, permission: 0 };
 		let encode_add_provider_data = wrap_binary_data(add_provider_payload.encode());
 
 		let signature: MultiSignature = key_pair_delegator.sign(&encode_add_provider_data).into();
@@ -590,9 +590,9 @@ pub fn create_sponsored_account_with_delegation_with_invalid_add_provider_should
 		assert_noop!(
 			Msa::create_sponsored_account_with_delegation(
 				Origin::signed(provider_account.into()),
-				delegator_account.clone().into(),
-				signature.clone(),
-				add_provider_payload.clone()
+				delegator_account.into(),
+				signature,
+				add_provider_payload
 			),
 			Error::<Test>::DuplicatedKey
 		);
@@ -609,7 +609,7 @@ pub fn create_sponsored_account_with_delegation_with_different_authorized_msa_id
 		let (key_pair_delegator, _) = sr25519::Pair::generate();
 		let delegator_account = key_pair_delegator.public();
 
-		let add_provider_payload = AddProvider { authorized_msa_id: 3u64.into(), permission: 0 };
+		let add_provider_payload = AddProvider { authorized_msa_id: 3u64, permission: 0 };
 		let encode_add_provider_data = wrap_binary_data(add_provider_payload.encode());
 
 		let signature: MultiSignature = key_pair_delegator.sign(&encode_add_provider_data).into();
@@ -620,9 +620,9 @@ pub fn create_sponsored_account_with_delegation_with_different_authorized_msa_id
 		assert_noop!(
 			Msa::create_sponsored_account_with_delegation(
 				Origin::signed(provider_account.into()),
-				delegator_account.clone().into(),
-				signature.clone(),
-				add_provider_payload.clone()
+				delegator_account.into(),
+				signature,
+				add_provider_payload
 			),
 			Error::<Test>::UnauthorizedProvider
 		);
@@ -719,8 +719,8 @@ pub fn revoke_provider_is_successful() {
 		assert_ok!(Msa::add_provider_to_msa(
 			test_origin_signed(1),
 			provider_account.into(),
-			signature.clone(),
-			add_provider_payload.clone()
+			signature,
+			add_provider_payload
 		));
 
 		let provider = Provider(2);
@@ -769,8 +769,8 @@ fn revoke_provider_throws_errors() {
 		assert_ok!(Msa::add_provider_to_msa(
 			test_origin_signed(1),
 			provider_account.into(),
-			signature.clone(),
-			add_provider_payload.clone()
+			signature,
+			add_provider_payload
 		));
 
 		assert_noop!(
@@ -799,14 +799,14 @@ pub fn revoke_provider_throws_delegation_not_found_error() {
 		assert_ok!(Msa::create(Origin::signed(provider_key.into())));
 		// 1. when delegator msa_id not found
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::DelegationNotFound
 		);
 
 		assert_ok!(Msa::create(Origin::signed(delegator_key.into())));
 		// 2. when no delegation relationship
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::DelegationNotFound
 		);
 
@@ -828,15 +828,15 @@ pub fn remove_delegation_by_provider_happy_path() {
 		assert_ok!(Msa::create(Origin::signed(provider_key.into())));
 
 		// 3. create delegator MSA and provider to provider
-		let add_provider_payload = AddProvider { authorized_msa_id: 1u64.into(), permission: 0 };
+		let add_provider_payload = AddProvider { authorized_msa_id: 1u64, permission: 0 };
 		let encode_add_provider_data = wrap_binary_data(add_provider_payload.encode());
 		let signature: MultiSignature = user_pair.sign(&encode_add_provider_data).into();
 		// 3.5 create the user's MSA + add provider as provider
 		assert_ok!(Msa::create_sponsored_account_with_delegation(
 			Origin::signed(provider_key.into()),
-			delegator_key.clone().into(),
-			signature.clone(),
-			add_provider_payload.clone()
+			delegator_key.into(),
+			signature,
+			add_provider_payload
 		));
 
 		//  4. set some block number to ensure it's not a default value
@@ -845,7 +845,7 @@ pub fn remove_delegation_by_provider_happy_path() {
 		// 5. assert_ok! fn as 2 to remove provider 1
 		assert_ok!(Msa::remove_delegation_by_provider(
 			Origin::signed(provider_key.into()),
-			2u64.into()
+			2u64
 		));
 
 		// 6. verify that the provider is revoked
@@ -881,7 +881,7 @@ pub fn remove_delegation_by_provider_errors_when_no_delegator_msa_id() {
 
 		// 0. when provider msa_id not found
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::NoKeyExists
 		);
 
@@ -891,14 +891,14 @@ pub fn remove_delegation_by_provider_errors_when_no_delegator_msa_id() {
 
 		// 1. when delegator msa_id not found
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::DelegationNotFound
 		);
 
 		assert_ok!(Msa::create(Origin::signed(delegator_key.into())));
 		// 2. when no delegation relationship
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::DelegationNotFound
 		);
 
@@ -906,7 +906,7 @@ pub fn remove_delegation_by_provider_errors_when_no_delegator_msa_id() {
 		assert_ok!(Msa::revoke_provider(Provider(1), Delegator(2)));
 		// 3. when_delegation_expired
 		assert_noop!(
-			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64.into()),
+			Msa::remove_delegation_by_provider(Origin::signed(provider_key.into()), 2u64),
 			Error::<Test>::DelegationRevoked
 		);
 	})

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -9,7 +9,7 @@ use codec::{Decode, Encode};
 pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 
 /// A type definition for the payload of adding an MSA key - `pallet_msa::add_key_to_msa`
-#[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq)]
+#[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Eq)]
 pub struct AddKeyData {
 	/// Message Source Account identifier
 	pub msa_id: MessageSourceId,
@@ -18,7 +18,7 @@ pub struct AddKeyData {
 }
 
 /// Structure that is signed for granting permissions to a Provider
-#[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq)]
+#[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Eq)]
 pub struct AddProvider {
 	/// The provider being granted permissions
 	pub authorized_msa_id: MessageSourceId,

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -49,8 +49,6 @@
 	rustdoc::invalid_codeblock_attributes
 )]
 
-
-
 use frame_support::{dispatch::DispatchResult, ensure, traits::Get, BoundedVec};
 
 #[cfg(test)]

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -49,7 +49,7 @@
 	rustdoc::invalid_codeblock_attributes
 )]
 
-use core;
+
 
 use frame_support::{dispatch::DispatchResult, ensure, traits::Get, BoundedVec};
 
@@ -104,7 +104,7 @@ pub mod pallet {
 		SchemaMaxSizeChanged(u32),
 	}
 
-	#[derive(PartialEq)] // for testing
+	#[derive(PartialEq, Eq)] // for testing
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Schema is malformed
@@ -166,7 +166,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			GovernanceSchemaFormatMaxBytes::<T>::put(self.initial_max_schema_format_size.clone());
+			GovernanceSchemaFormatMaxBytes::<T>::put(self.initial_max_schema_format_size);
 		}
 	}
 
@@ -195,7 +195,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			schema: BoundedVec<u8, T::SchemaFormatMaxBytesBoundedVecLimit>,
 		) -> DispatchResult {
-			let sender = ensure_signed(origin.clone())?;
+			let sender = ensure_signed(origin)?;
 
 			ensure!(
 				schema.len() > T::MinSchemaFormatSizeBytes::get() as usize,
@@ -210,7 +210,7 @@ pub mod pallet {
 			ensure!(cur_count < T::MaxSchemaRegistrations::get(), Error::<T>::TooManySchemas);
 			let schema_id = cur_count.checked_add(1).ok_or(Error::<T>::SchemaCountOverflow)?;
 
-			Self::add_schema(schema.clone(), schema_id)?;
+			Self::add_schema(schema, schema_id)?;
 
 			Self::deposit_event(Event::SchemaRegistered(sender, schema_id));
 			Ok(())
@@ -220,7 +220,7 @@ pub mod pallet {
 		/// Schema BoundedVec used for registration.
 		#[pallet::weight(30_000)]
 		pub fn set_max_schema_format_bytes(origin: OriginFor<T>, max_size: u32) -> DispatchResult {
-			ensure_root(origin.clone())?;
+			ensure_root(origin)?;
 			ensure!(
 				max_size <= T::SchemaFormatMaxBytesBoundedVecLimit::get(),
 				Error::<T>::ExceedsGovernanceSchemaFormatMaxValue

--- a/pallets/schemas/src/mock.rs
+++ b/pallets/schemas/src/mock.rs
@@ -3,7 +3,7 @@ use frame_support::{
 	traits::{ConstU16, ConstU32, ConstU64},
 	weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial},
 };
-use frame_system;
+
 use smallvec::smallvec;
 use sp_core::H256;
 use sp_runtime::{

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -74,8 +74,7 @@ where
 					code: ErrorCode::ServerError(1),
 					message: "No schema found".into(),
 					data: None,
-				}
-				.into()),
+				}),
 			},
 			Err(e) => Err(RpcError {
 				code: ErrorCode::ServerError(1),


### PR DESCRIPTION
Clippy had a few auto-fixable lints that cleaned up some code.

Examples:
- Removing unneeded `into` calls
- Removing unneeded `clone` calls (for things that support [Copy](https://doc.rust-lang.org/std/marker/trait.Copy.html))
- Removing unneeded borrowing (usually for a call that is the last use of a variable)
- Removing unneeded unwrapping and re-wrapping with Ok(xxx?)
- Removing unused imports