### PR TITLE
Rename Schema.Format to Schema.Model

### DIFF
--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -15,7 +15,7 @@ use utils::*;
 #[derive(Default, Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
 pub struct MessageResponse<AccountId, BlockNumber> {
 	#[cfg_attr(feature = "std", serde(with = "as_hex"))]
-	/// Serialized data in a user-defined schema format.
+	/// Serialized data in a the schemas.
 	pub payload: Vec<u8>,
 	/// The public key of the provider and the signer of the transaction.
 	pub provider_key: AccountId,

--- a/common/primitives/src/schema.rs
+++ b/common/primitives/src/schema.rs
@@ -19,5 +19,5 @@ pub struct SchemaResponse {
 	pub schema_id: SchemaId,
 	/// The data that represents how this schema is structured
 	#[cfg_attr(feature = "std", serde(with = "as_string"))]
-	pub format: Vec<u8>,
+	pub model: Vec<u8>,
 }

--- a/js/rpc/definitions/schemas.js
+++ b/js/rpc/definitions/schemas.js
@@ -32,8 +32,8 @@ export default {
             optional: true,
           },
           {
-            name: "format",
-            type: "SchemaFormat",
+            name: "model",
+            type: "SchemaModel",
           },
         ],
         type: "bool",
@@ -42,10 +42,10 @@ export default {
   },
   types: {
     SchemaId: "u16",
-    SchemaFormat: "Vec<u8>",
+    SchemaModel: "Vec<u8>",
     SchemaResponse: {
       schema_id: "SchemaId",
-      format: "SchemaFormat",
+      model: "SchemaModel",
     },
   },
 };

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -11,7 +11,7 @@ pub struct Message<AccountId, MaxDataSize>
 where
 	MaxDataSize: Get<u32> + Clone,
 {
-	///  Serialized data in a user-defined schema format
+	///  Data structured by the associated schema's model
 	pub payload: BoundedVec<u8, MaxDataSize>,
 	///  Public key of the provider that signed the transaction
 	pub provider_key: AccountId,

--- a/pallets/schemas/src/benchmarking.rs
+++ b/pallets/schemas/src/benchmarking.rs
@@ -10,13 +10,13 @@ const SCHEMAS: u32 = 1000;
 
 fn generate_schema<T: Config>(
 	size: usize,
-) -> BoundedVec<u8, T::SchemaFormatMaxBytesBoundedVecLimit> {
+) -> BoundedVec<u8, T::SchemaModelMaxBytesBoundedVecLimit> {
 	let input = vec![1; size as usize];
 	input.try_into().unwrap()
 }
 
 fn register_some_schema<T: Config>(sender: T::AccountId) -> DispatchResult {
-	let schema_size: usize = (T::SchemaFormatMaxBytesBoundedVecLimit::get() / 2) as usize;
+	let schema_size: usize = (T::SchemaModelMaxBytesBoundedVecLimit::get() / 2) as usize;
 	SchemasPallet::<T>::register_schema(
 		RawOrigin::Signed(sender).into(),
 		generate_schema::<T>(schema_size),
@@ -25,10 +25,10 @@ fn register_some_schema<T: Config>(sender: T::AccountId) -> DispatchResult {
 
 benchmarks! {
 	register_schema {
-		let m in (T::MinSchemaFormatSizeBytes::get() + 1) .. (T::SchemaFormatMaxBytesBoundedVecLimit::get() - 1);
+		let m in (T::MinSchemaModelSizeBytes::get() + 1) .. (T::SchemaModelMaxBytesBoundedVecLimit::get() - 1);
 		let n in 1 .. SCHEMAS;
 		let sender: T::AccountId = whitelisted_caller();
-		assert_ok!(SchemasPallet::<T>::set_max_schema_format_bytes(RawOrigin::Root.into(), T::SchemaFormatMaxBytesBoundedVecLimit::get()));
+		assert_ok!(SchemasPallet::<T>::set_max_schema_model_bytes(RawOrigin::Root.into(), T::SchemaModelMaxBytesBoundedVecLimit::get()));
 		for j in 0..(n) {
 			assert_ok!(register_some_schema::<T>(sender.clone()));
 		}

--- a/pallets/schemas/src/mock.rs
+++ b/pallets/schemas/src/mock.rs
@@ -53,10 +53,10 @@ impl WeightToFeePolynomial for WeightToFee {
 impl pallet_schemas::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
-	type MinSchemaFormatSizeBytes = ConstU32<5>;
+	type MinSchemaModelSizeBytes = ConstU32<5>;
 	// a very high limit on incoming schema size, expected to be much higher than what
 	// is actually allowed.
-	type SchemaFormatMaxBytesBoundedVecLimit = ConstU32<65_000>;
+	type SchemaModelMaxBytesBoundedVecLimit = ConstU32<65_000>;
 	type MaxSchemaRegistrations = MaxSchemaRegistrations;
 }
 

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -41,9 +41,9 @@ pub trait SchemasApi<BlockHash> {
 	#[rpc(name = "schemas_getBySchemaId")]
 	fn get_by_schema_id(&self, schema_id: SchemaId) -> Result<Option<SchemaResponse>>;
 
-	/// validates a schema format and returns `true` if the format is correct.
+	/// validates a schema model and returns `true` if the model is correct.
 	#[rpc(name = "schemas_checkSchemaValidity")]
-	fn check_schema_validity(&self, at: Option<BlockHash>, format: Vec<u8>) -> Result<bool>;
+	fn check_schema_validity(&self, at: Option<BlockHash>, model: Vec<u8>) -> Result<bool>;
 }
 
 pub struct SchemasHandler<C, M> {
@@ -87,9 +87,9 @@ where
 	fn check_schema_validity(
 		&self,
 		_at: Option<<Block as BlockT>::Hash>,
-		format: Vec<u8>,
+		model: Vec<u8>,
 	) -> Result<bool> {
-		let validated_schema = avro::validate_raw_avro_schema(&format);
+		let validated_schema = avro::validate_raw_avro_schema(&model);
 		match validated_schema {
 			Ok(_) => Ok(true),
 			Err(e) => Err(RpcError {

--- a/pallets/schemas/src/tests.rs
+++ b/pallets/schemas/src/tests.rs
@@ -8,13 +8,13 @@ use super::mock::*;
 
 fn create_bounded_schema_vec(
 	from_string: &str,
-) -> BoundedVec<u8, <Test as Config>::SchemaFormatMaxBytesBoundedVecLimit> {
+) -> BoundedVec<u8, <Test as Config>::SchemaModelMaxBytesBoundedVecLimit> {
 	let fields_vec = Vec::from(from_string.as_bytes());
 	BoundedVec::try_from(fields_vec).unwrap()
 }
 
 fn sudo_set_max_schema_size() {
-	assert_ok!(SchemasPallet::set_max_schema_format_bytes(RawOrigin::Root.into(), 50));
+	assert_ok!(SchemasPallet::set_max_schema_model_bytes(RawOrigin::Root.into(), 50));
 }
 
 pub mod test {}
@@ -32,11 +32,11 @@ fn require_valid_schema_size_errors() {
 		let test_cases: [TestCase<(Error<Test>, u8)>; 2] = [
 			TestCase {
 				schema: "",
-				expected: (Error::<Test>::LessThanMinSchemaFormatBytes,3),
+				expected: (Error::<Test>::LessThanMinSchemaModelBytes,3),
 			},
 			TestCase {
 				schema: "foo,bar,bazz,way,wayway,wayway,foo,bar,bazz,way,wayway,wayway,foo,bar,bazz,thisiswaywaywaywaywaywaywaytoolong",
-				expected: (Error::<Test>::ExceedsMaxSchemaFormatBytes, 2),
+				expected: (Error::<Test>::ExceedsMaxSchemaModelBytes, 2),
 			},
 		];
 		for tc in test_cases {
@@ -72,8 +72,8 @@ fn register_schema_happy_path() {
 fn set_max_schema_size_works_if_root() {
 	new_test_ext().execute_with(|| {
 		let new_size: u32 = 42;
-		assert_ok!(SchemasPallet::set_max_schema_format_bytes(RawOrigin::Root.into(), new_size));
-		let new_schema_size = SchemasPallet::get_schema_format_max_bytes();
+		assert_ok!(SchemasPallet::set_max_schema_model_bytes(RawOrigin::Root.into(), new_size));
+		let new_schema_size = SchemasPallet::get_schema_model_max_bytes();
 		assert_eq!(new_size, new_schema_size);
 	})
 }
@@ -85,7 +85,7 @@ fn set_max_schema_size_fails_if_not_root() {
 		let sender: AccountId = 1;
 		let expected_err = BadOrigin;
 		assert_noop!(
-			SchemasPallet::set_max_schema_format_bytes(Origin::signed(sender), new_size),
+			SchemasPallet::set_max_schema_model_bytes(Origin::signed(sender), new_size),
 			expected_err
 		);
 	})
@@ -95,9 +95,9 @@ fn set_max_schema_size_fails_if_not_root() {
 fn set_max_schema_size_fails_if_larger_than_bound() {
 	new_test_ext().execute_with(|| {
 		let new_size: u32 = 68_000;
-		let expected_err = Error::<Test>::ExceedsGovernanceSchemaFormatMaxValue;
+		let expected_err = Error::<Test>::ExceedsGovernanceSchemaModelMaxValue;
 		assert_noop!(
-			SchemasPallet::set_max_schema_format_bytes(RawOrigin::Root.into(), new_size),
+			SchemasPallet::set_max_schema_model_bytes(RawOrigin::Root.into(), new_size),
 			expected_err
 		);
 	})
@@ -146,7 +146,7 @@ fn get_existing_schema_by_id_should_return_schema() {
 
 		// assert
 		assert_eq!(res.as_ref().is_some(), true);
-		assert_eq!(res.as_ref().unwrap().clone().format, serialized_fields);
+		assert_eq!(res.as_ref().unwrap().clone().model, serialized_fields);
 	})
 }
 

--- a/pallets/schemas/src/weights.rs
+++ b/pallets/schemas/src/weights.rs
@@ -59,7 +59,7 @@ pub trait WeightInfo {
 /// Weights for pallet_schemas using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	// Storage: Schemas GovernanceSchemaFormatMaxBytes (r:1 w:0)
+	// Storage: Schemas GovernanceSchemaModelMaxBytes (r:1 w:0)
 	// Storage: Schemas SchemaCount (r:1 w:1)
 	// Storage: Schemas Schemas (r:0 w:1)
 	fn register_schema(_m: u32, n: u32, ) -> Weight {
@@ -73,7 +73,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	// Storage: Schemas GovernanceSchemaFormatMaxBytes (r:1 w:0)
+	// Storage: Schemas GovernanceSchemaModelMaxBytes (r:1 w:0)
 	// Storage: Schemas SchemaCount (r:1 w:1)
 	// Storage: Schemas Schemas (r:0 w:1)
 	fn register_schema(_m: u32, n: u32, ) -> Weight {

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -322,9 +322,9 @@ impl pallet_schemas::Config for Runtime {
 	type WeightInfo = pallet_schemas::weights::SubstrateWeight<Runtime>;
 
 	// TODO: these constants need to be determined. See Issue #70
-	type MinSchemaFormatSizeBytes = ConstU32<5>;
+	type MinSchemaModelSizeBytes = ConstU32<5>;
 	type MaxSchemaRegistrations = MaxSchemaRegistrations;
-	type SchemaFormatMaxBytesBoundedVecLimit = ConstU32<65_500>;
+	type SchemaModelMaxBytesBoundedVecLimit = ConstU32<65_500>;
 }
 
 impl pallet_tx_fee::Config for Runtime {}


### PR DESCRIPTION
Last renaming, promise.

Schema format wasn't working well. Switching to Schema Model.

Note: https://github.com/LibertyDSNP/mrc/blob/main/designdocs/README.md model image updated in the design doc image repo.