### PR TITLE
Docker port collision fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ source .env
     ./scripts/init.sh start-relay-chain
     ```
 
-1. Relay chain is running on port [`9945`](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) and [`9946`](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9946#/explorer) for alice and bob respectively.
+1. Relay chain is running on ports:
+    | Host | Port | URL |
+    | ---- | ---- | --- |
+    | MRC Relay Node | `9945` | [127.0.0.1:9945](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9945#/explorer) |
+    | Alice Relay Node | `9946` | [127.0.0.1:9946](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9946#/explorer) |
+    | Bob Relay Node | `9947` | [127.0.0.1:9947](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9947#/explorer) |
 
 1. Register a new parachain slot (parachain id) for MRC:
 
@@ -85,7 +90,7 @@ source .env
     ./scripts/init.sh onboard-mrc
     ```
 
-1. Parachain collator will be available at  port `$9944`.
+1. Parachain collator will be available at rpc port `9944`.
 
 1. Link to parachain [dashboard](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944)
 
@@ -104,15 +109,20 @@ Note: Clean up /tmp/mrc directory after off-boarding. This is required to avoid 
       - ```9933```  # rpc port
       - ```9944```  # ws port
 
-- Default ports for Validator Alice are:
+- Default ports for MRC Relay Chain Node are:
       - ```30334``` # p2p port
       - ```9934```  # rpc port
       - ```9945```  # ws port
 
-- Default ports for Validator Bob are:
+- Default ports for Validator Alice are:
       - ```30335``` # p2p port
       - ```9935```  # rpc port
       - ```9946```  # ws port
+
+- Default ports for Validator Bob are:
+      - ```30336``` # p2p port
+      - ```9936```  # rpc port
+      - ```9947```  # ws port
 
 ### Cleanup the environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     image: "parity/polkadot:v0.9.18"
     hostname: relay_alice
     ports:
-      - "30334:30334" # p2p port
-      - "9934:9933" # rpc port
-      - "9945:9944" # ws port
+      - "30335:30335" # p2p port
+      - "9935:9933" # rpc port
+      - "9946:9944" # ws port
     volumes:
       - type: bind
         source: ./res/rococo-local.json
@@ -36,9 +36,9 @@ services:
     image: "parity/polkadot:v0.9.18"
     hostname: relay_bob
     ports:
-      - "30335:30335" # p2p port
-      - "9935:9933" # rpc port
-      - "9946:9944" # ws port
+      - "30336:30336" # p2p port
+      - "9936:9933" # rpc port
+      - "9947:9944" # ws port
     volumes:
       - type: bind
         source: ./res/rococo-local.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: "parity/polkadot:v0.9.18"
     hostname: relay_alice
     ports:
-      - "30334:30333" # p2p port
+      - "30334:30334" # p2p port
       - "9934:9933" # rpc port
       - "9945:9944" # ws port
     volumes:
@@ -21,7 +21,7 @@ services:
       --wasm-execution=compiled
       --execution=wasm
       --base-path=/data
-      --port 30333
+      --port 30334
       --rpc-port 9933
       --ws-port 9944
       --rpc-external
@@ -36,7 +36,7 @@ services:
     image: "parity/polkadot:v0.9.18"
     hostname: relay_bob
     ports:
-      - "30335:30333" # p2p port
+      - "30335:30335" # p2p port
       - "9935:9933" # rpc port
       - "9946:9944" # ws port
     volumes:
@@ -50,7 +50,7 @@ services:
       --base-path=/data
       --wasm-execution=compiled
       --execution=wasm
-      --port 30333
+      --port 30335
       --rpc-port 9933
       --ws-port 9944
       --rpc-external
@@ -71,7 +71,7 @@ services:
       - ALICE_RPC_PORT=9933
       - BOB_RPC_PORT=9933
     ports:
-      - "30333:30333" # p2p port 
+      - "30333:30333" # p2p port
       - "9933:9933" # rpc port
       - "9944:9944" # ws port
     depends_on:

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -100,7 +100,7 @@ register-mrc)
   echo "reserving and registering parachain with relay via first available slot..."
 
   cd scripts/js/onboard
-  yarn && yarn register "ws://0.0.0.0:9945" "//Alice"
+  yarn && yarn register "ws://0.0.0.0:9946" "//Alice"
   ;;
 
 onboard-mrc)
@@ -121,13 +121,13 @@ onboard-mrc)
   echo "WASM path:" "${parachain}-${para_id}.wasm"
 
   cd scripts/js/onboard
-  yarn && yarn onboard "ws://0.0.0.0:9945" "//Alice" ${para_id} "${genesis}" $wasm_location
+  yarn && yarn onboard "ws://0.0.0.0:9946" "//Alice" ${para_id} "${genesis}" $wasm_location
   ;;
 
 offboard-mrc)
   echo "cleaning up parachain for id '$para_id'..."
 
   cd scripts/js/onboard
-  yarn && yarn cleanup "ws://0.0.0.0:9945" "//Alice" ${para_id}
+  yarn && yarn cleanup "ws://0.0.0.0:9946" "//Alice" ${para_id}
   ;;
 esac

--- a/scripts/run_collator.sh
+++ b/scripts/run_collator.sh
@@ -17,8 +17,8 @@ args=( "$@" )
 
 alice="${HOST_ALICE:-127.0.0.1}"
 bob="${HOST_BOB:-127.0.0.1}"
-alice_rpc_port="${ALICE_RPC_PORT:-9934}"
-bob_rpc_port="${BOB_RPC_PORT:-9935}"
+alice_rpc_port="${ALICE_RPC_PORT:-9935}"
+bob_rpc_port="${BOB_RPC_PORT:-9936}"
 chain="${RELAY_CHAIN_SPEC:-./res/rococo-local.json}"
 
 get_bootnode () {


### PR DESCRIPTION
Two issues:

1. When using `system_localListenAddresses` because the p2p ports were different between the docker network and the host network, it returned the wrong port in the host network situation.
    - Solution: Use the same p2p port inside and outside the docker network
2. The MRC Collator starts up a relay chain node... that defaults to ports that where in use by the Alice relay node. So if you called rpc port 9945 outside of the docker network, you wouldn't know which node you were talking to.
    - Solution: Moved Alice and Bob relay chain node ports to +1. (So +2 the default for Alice and +3 the default for Bob)